### PR TITLE
Remove unused fields

### DIFF
--- a/examples/dockerscaleset/main.go
+++ b/examples/dockerscaleset/main.go
@@ -80,11 +80,9 @@ func run(ctx context.Context, c Config) error {
 		Labels: []scaleset.Label{
 			{
 				Name: c.ScaleSetName,
-				Type: "System",
 			},
 		},
 		RunnerSetting: scaleset.RunnerSetting{
-			Ephemeral:     true,
 			DisableUpdate: true,
 		},
 	})

--- a/types.go
+++ b/types.go
@@ -17,11 +17,6 @@ const (
 	MessageTypeJobCompleted MessageType = "JobCompleted"
 )
 
-type JobAvailable struct {
-	AcquireJobURL string `json:"acquireJobUrl"`
-	JobMessageBase
-}
-
 type JobAssigned struct {
 	JobMessageBase
 }
@@ -134,8 +129,6 @@ type RunnerScaleSetStatistic struct {
 }
 
 type RunnerSetting struct {
-	Ephemeral     bool `json:"ephemeral,omitempty"`
-	IsElastic     bool `json:"isElastic,omitempty"`
 	DisableUpdate bool `json:"disableUpdate,omitempty"`
 }
 


### PR DESCRIPTION
This removes fields that have no effect in the API anymore + it adds a default `Type` value for `Labels` (`"System"`) if left empty: it's an old API detail and we shouldn't be expecting users to set it and what to set it to.