### PR TITLE
Use *slog.Logger instead of slog.Logger in option

### DIFF
--- a/common_client.go
+++ b/common_client.go
@@ -146,7 +146,7 @@ func (c *commonClient) setUserAgent() {
 type HTTPOption func(*httpClientOption)
 
 // WithLogger sets a custom logger for the Client.
-// If nil is passed, discard handler will be used
+// If nil is passed, a discard logger will be used.
 func WithLogger(logger *slog.Logger) HTTPOption {
 	return func(c *httpClientOption) {
 		if logger == nil {


### PR DESCRIPTION
This change makes it nicer to use `logger.With()` which returns `*slog.Logger`