### PR TITLE
Add top level errors conforming to http codes

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -20,6 +20,10 @@ var (
 	RunnerExistsError             = scalesetError("runner exists")
 	JobStillRunningError          = scalesetError("job still running")
 	MessageQueueTokenExpiredError = scalesetError("message queue token expired")
+	// BadRequest is used when the error is not from the HTTP client, but from the application logic,
+	// such as invalid request body, missing required parameters, etc. It indicates that the request was malformed or invalid.
+	BadRequest   = scalesetError("bad request")
+	Unauthorized = scalesetError("unauthorized")
 )
 
 type actionsExceptionError struct {
@@ -87,12 +91,23 @@ func newRequestResponseError(req *http.Request, resp *http.Response, err error) 
 
 	switch {
 	case strings.Contains(exception.ExceptionName, "AgentExistsException"):
-		return fmt.Errorf("%s: %w: %s", sb.String(), RunnerExistsError, exception.Message)
+		return wrapResponseErrorType(resp, fmt.Errorf("%s: %w: %s", sb.String(), RunnerExistsError, exception.Message))
 	case strings.Contains(exception.ExceptionName, "AgentNotFoundException"):
-		return fmt.Errorf("%s: %w: %s", sb.String(), RunnerNotFoundError, exception.Message)
+		return wrapResponseErrorType(resp, fmt.Errorf("%s: %w: %s", sb.String(), RunnerNotFoundError, exception.Message))
 	case strings.Contains(exception.ExceptionName, "JobStillRunningException"):
-		return fmt.Errorf("%s: %w: %s", sb.String(), JobStillRunningError, exception.Message)
+		return wrapResponseErrorType(resp, fmt.Errorf("%s: %w: %s", sb.String(), JobStillRunningError, exception.Message))
 	default:
-		return fmt.Errorf("%s: %w: %w", sb.String(), err, exception)
+		return wrapResponseErrorType(resp, fmt.Errorf("%s: %w: %w", sb.String(), err, exception))
+	}
+}
+
+func wrapResponseErrorType(resp *http.Response, err error) error {
+	switch resp.StatusCode {
+	case http.StatusBadRequest:
+		return fmt.Errorf("%w: %w", BadRequest, err)
+	case http.StatusUnauthorized:
+		return fmt.Errorf("%w: %w", Unauthorized, err)
+	default:
+		return err
 	}
 }

--- a/errors.go
+++ b/errors.go
@@ -20,9 +20,9 @@ var (
 	RunnerExistsError             = scalesetError("runner exists")
 	JobStillRunningError          = scalesetError("job still running")
 	MessageQueueTokenExpiredError = scalesetError("message queue token expired")
-	// BadRequest is used when the error is not from the HTTP client, but from the application logic,
-	// such as invalid request body, missing required parameters, etc. It indicates that the request was malformed or invalid.
+	// Top level errors carying the http status code meanings.
 	BadRequest   = scalesetError("bad request")
+	NotFound     = scalesetError("not found")
 	Unauthorized = scalesetError("unauthorized")
 )
 
@@ -107,6 +107,8 @@ func wrapResponseErrorType(resp *http.Response, err error) error {
 		return fmt.Errorf("%w: %w", BadRequest, err)
 	case http.StatusUnauthorized:
 		return fmt.Errorf("%w: %w", Unauthorized, err)
+	case http.StatusNotFound:
+		return fmt.Errorf("%w: %w", NotFound, err)
 	default:
 		return err
 	}

--- a/errors.go
+++ b/errors.go
@@ -21,9 +21,10 @@ var (
 	JobStillRunningError          = scalesetError("job still running")
 	MessageQueueTokenExpiredError = scalesetError("message queue token expired")
 	// Top level errors carying the http status code meanings.
-	BadRequest   = scalesetError("bad request")
-	NotFound     = scalesetError("not found")
-	Unauthorized = scalesetError("unauthorized")
+	BadRequestError   = scalesetError("bad request")
+	NotFoundError     = scalesetError("not found")
+	UnauthorizedError = scalesetError("unauthorized")
+	ConflictError     = scalesetError("conflict")
 )
 
 type actionsExceptionError struct {
@@ -63,30 +64,30 @@ func newRequestResponseError(req *http.Request, resp *http.Response, err error) 
 	sb.WriteRune(')')
 
 	if resp.Body == nil || resp.ContentLength == 0 {
-		return fmt.Errorf("%s: %w: unknown error", sb.String(), err)
+		return wrapResponseErrorType(resp, fmt.Errorf("%s: %w: unknown error", sb.String(), err))
 	}
 
 	body, bodyErr := io.ReadAll(resp.Body)
 	if bodyErr != nil {
-		return fmt.Errorf("%s: %w: failed to read error response body: %w", sb.String(), err, bodyErr)
+		return wrapResponseErrorType(resp, fmt.Errorf("%s: %w: failed to read error response body: %w", sb.String(), err, bodyErr))
 	}
 	if len(body) == 0 {
-		return fmt.Errorf("%s: %w: unknown error", sb.String(), err)
+		return wrapResponseErrorType(resp, fmt.Errorf("%s: %w: unknown error", sb.String(), err))
 	}
 
 	var scalesetErr scalesetError
 	if errors.As(err, &scalesetErr) {
-		return fmt.Errorf("%s: %w: %s", sb.String(), err, string(body))
+		return wrapResponseErrorType(resp, fmt.Errorf("%s: %w: %s", sb.String(), err, string(body)))
 	}
 
 	contentType := resp.Header.Get("Content-Type")
 	if len(contentType) > 0 && strings.Contains(contentType, "text/plain") {
-		return fmt.Errorf("%s: %w: %s", sb.String(), err, string(body))
+		return wrapResponseErrorType(resp, fmt.Errorf("%s: %w: %s", sb.String(), err, string(body)))
 	}
 
 	var exception actionsExceptionError
 	if err := json.Unmarshal(body, &exception); err != nil {
-		return fmt.Errorf("%s: %w: failed to unmarshal error response body: %q", sb.String(), err, string(body))
+		return wrapResponseErrorType(resp, fmt.Errorf("%s: %w: failed to unmarshal error response body: %q", sb.String(), err, string(body)))
 	}
 
 	switch {
@@ -104,11 +105,13 @@ func newRequestResponseError(req *http.Request, resp *http.Response, err error) 
 func wrapResponseErrorType(resp *http.Response, err error) error {
 	switch resp.StatusCode {
 	case http.StatusBadRequest:
-		return fmt.Errorf("%w: %w", BadRequest, err)
+		return fmt.Errorf("%w: %w", BadRequestError, err)
 	case http.StatusUnauthorized:
-		return fmt.Errorf("%w: %w", Unauthorized, err)
+		return fmt.Errorf("%w: %w", UnauthorizedError, err)
 	case http.StatusNotFound:
-		return fmt.Errorf("%w: %w", NotFound, err)
+		return fmt.Errorf("%w: %w", NotFoundError, err)
+	case http.StatusConflict:
+		return fmt.Errorf("%w: %w", ConflictError, err)
 	default:
 		return err
 	}

--- a/errors.go
+++ b/errors.go
@@ -20,7 +20,7 @@ var (
 	RunnerExistsError             = scalesetError("runner exists")
 	JobStillRunningError          = scalesetError("job still running")
 	MessageQueueTokenExpiredError = scalesetError("message queue token expired")
-	// Top level errors carying the http status code meanings.
+	// Top-level errors carrying the HTTP status code meanings.
 	BadRequestError   = scalesetError("bad request")
 	NotFoundError     = scalesetError("not found")
 	UnauthorizedError = scalesetError("unauthorized")

--- a/errors_test.go
+++ b/errors_test.go
@@ -44,7 +44,7 @@ func TestNewRequestResponseError(t *testing.T) {
 		err := newRequestResponseError(req(t), nil, base)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "request GET https://example.com/org/repo failed")
-		assert.True(t, errors.Is(err, base))
+		assert.ErrorIs(t, err, base)
 	})
 
 	t.Run("resp body is nil", func(t *testing.T) {
@@ -60,7 +60,7 @@ func TestNewRequestResponseError(t *testing.T) {
 		err := newRequestResponseError(req(t), resp, base)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "unknown error")
-		assert.True(t, errors.Is(err, base))
+		assert.ErrorIs(t, err, base)
 	})
 
 	t.Run("empty body returns unknown error", func(t *testing.T) {
@@ -76,11 +76,12 @@ func TestNewRequestResponseError(t *testing.T) {
 
 		err := newRequestResponseError(req(t), resp, base)
 		require.Error(t, err)
+		assert.ErrorIs(t, err, NotFoundError)
 		assert.Contains(t, err.Error(), "status=\"404 Not Found\"")
 		assert.Contains(t, err.Error(), "activity_id=\"activity-id\"")
 		assert.Contains(t, err.Error(), "github_request_id=\"request-id\"")
 		assert.Contains(t, err.Error(), "unknown error")
-		assert.True(t, errors.Is(err, base))
+		assert.ErrorIs(t, err, base)
 	})
 
 	t.Run("read body failure includes read error", func(t *testing.T) {
@@ -96,7 +97,7 @@ func TestNewRequestResponseError(t *testing.T) {
 		err := newRequestResponseError(req(t), resp, base)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to read error response body")
-		assert.True(t, errors.Is(err, base))
+		assert.ErrorIs(t, err, base)
 		assert.Contains(t, err.Error(), "read failed")
 	})
 
@@ -113,7 +114,7 @@ func TestNewRequestResponseError(t *testing.T) {
 		err := newRequestResponseError(req(t), resp, base)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "unknown error")
-		assert.True(t, errors.Is(err, base))
+		assert.ErrorIs(t, err, base)
 	})
 
 	t.Run("text/plain body is included", func(t *testing.T) {
@@ -132,7 +133,7 @@ func TestNewRequestResponseError(t *testing.T) {
 		err := newRequestResponseError(req(t), resp, base)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), body)
-		assert.True(t, errors.Is(err, base))
+		assert.ErrorIs(t, err, base)
 	})
 
 	t.Run("scalesetError in error chain uses raw body (no JSON parsing)", func(t *testing.T) {
@@ -149,7 +150,7 @@ func TestNewRequestResponseError(t *testing.T) {
 
 		err := newRequestResponseError(req(t), resp, wrapped)
 		require.Error(t, err)
-		assert.True(t, errors.Is(err, RunnerNotFoundError))
+		assert.ErrorIs(t, err, RunnerNotFoundError)
 		assert.Contains(t, err.Error(), body)
 	})
 
@@ -167,8 +168,9 @@ func TestNewRequestResponseError(t *testing.T) {
 
 		err := newRequestResponseError(req(t), resp, base)
 		require.Error(t, err)
-		assert.True(t, errors.Is(err, RunnerExistsError))
-		assert.False(t, errors.Is(err, base), "base error should not be wrapped for mapped exceptions")
+		assert.ErrorIs(t, err, RunnerExistsError)
+		assert.ErrorIs(t, err, ConflictError)
+		assert.NotErrorIs(t, err, base, "base error should not be wrapped for mapped exceptions")
 		assert.Contains(t, err.Error(), "runner already exists")
 	})
 
@@ -186,8 +188,8 @@ func TestNewRequestResponseError(t *testing.T) {
 
 		err := newRequestResponseError(req(t), resp, base)
 		require.Error(t, err)
-		assert.True(t, errors.Is(err, RunnerNotFoundError))
-		assert.False(t, errors.Is(err, base))
+		assert.ErrorIs(t, err, RunnerNotFoundError)
+		assert.NotErrorIs(t, err, base)
 		assert.Contains(t, err.Error(), "missing")
 	})
 
@@ -205,8 +207,9 @@ func TestNewRequestResponseError(t *testing.T) {
 
 		err := newRequestResponseError(req(t), resp, base)
 		require.Error(t, err)
-		assert.True(t, errors.Is(err, JobStillRunningError))
-		assert.False(t, errors.Is(err, base))
+		assert.ErrorIs(t, err, JobStillRunningError)
+		assert.ErrorIs(t, err, ConflictError)
+		assert.NotErrorIs(t, err, base)
 		assert.Contains(t, err.Error(), "still running")
 	})
 
@@ -226,7 +229,7 @@ func TestNewRequestResponseError(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to unmarshal error response body")
 		assert.Contains(t, err.Error(), "not-json")
-		assert.False(t, errors.Is(err, base), "base error is not wrapped on JSON unmarshal failures")
+		assert.NotErrorIs(t, err, base, "base error is not wrapped on JSON unmarshal failures")
 	})
 
 	t.Run("unknown json error wraps exception", func(t *testing.T) {
@@ -243,7 +246,7 @@ func TestNewRequestResponseError(t *testing.T) {
 
 		err := newRequestResponseError(req(t), resp, base)
 		require.Error(t, err)
-		assert.True(t, errors.Is(err, base))
+		assert.ErrorIs(t, err, base)
 
 		var ex actionsExceptionError
 		assert.True(t, errors.As(err, &ex))


### PR DESCRIPTION
This PR can help diagnose bad requests, or not found responses, allowing easier inspection of misconfigurations, since status codes carry useful pieces of information.