### PR TITLE
Add mTLS client certificate support for proxy authentication

### DIFF
--- a/common_client.go
+++ b/common_client.go
@@ -85,6 +85,7 @@ type httpClientOption struct {
 	// fields added to the transport if specified
 	rootCAs               *x509.CertPool
 	tlsInsecureSkipVerify bool
+	tlsClientCertificates []tls.Certificate
 	proxyFunc             ProxyFunc
 	timeout               time.Duration
 
@@ -138,6 +139,10 @@ func (o *httpClientOption) newRetryableHTTPClient() (*retryablehttp.Client, erro
 
 	if o.tlsInsecureSkipVerify {
 		transport.TLSClientConfig.InsecureSkipVerify = true
+	}
+
+	if len(o.tlsClientCertificates) > 0 {
+		transport.TLSClientConfig.Certificates = o.tlsClientCertificates
 	}
 
 	if o.proxyFunc != nil {
@@ -212,6 +217,24 @@ func WithoutTLSVerify() HTTPOption {
 	return func(c *httpClientOption) {
 		c.tlsInsecureSkipVerify = true
 	}
+}
+
+// WithTLSClientCertificate configures a TLS client certificate for mTLS authentication.
+// This is useful when connecting through proxies that require client certificate authentication.
+func WithTLSClientCertificate(cert tls.Certificate) HTTPOption {
+	return func(c *httpClientOption) {
+		c.tlsClientCertificates = append(c.tlsClientCertificates, cert)
+	}
+}
+
+// WithTLSClientCertificateFromFile loads a TLS client certificate and key from files
+// for mTLS authentication. This is a convenience function that wraps WithTLSClientCertificate.
+func WithTLSClientCertificateFromFile(certFile, keyFile string) (HTTPOption, error) {
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load client certificate: %w", err)
+	}
+	return WithTLSClientCertificate(cert), nil
 }
 
 // WithProxy sets a custom proxy function for the Client.

--- a/common_client.go
+++ b/common_client.go
@@ -142,7 +142,10 @@ func (o *httpClientOption) newRetryableHTTPClient() (*retryablehttp.Client, erro
 	}
 
 	if len(o.tlsClientCertificates) > 0 {
-		transport.TLSClientConfig.Certificates = o.tlsClientCertificates
+		transport.TLSClientConfig.Certificates = append(
+			transport.TLSClientConfig.Certificates,
+			o.tlsClientCertificates...,
+		)
 	}
 
 	if o.proxyFunc != nil {
@@ -220,15 +223,19 @@ func WithoutTLSVerify() HTTPOption {
 }
 
 // WithTLSClientCertificate configures a TLS client certificate for mTLS authentication.
-// This is useful when connecting through proxies that require client certificate authentication.
+// Note: The certificate is added to the TLS transport configuration and will be presented
+// during TLS handshakes for ALL connections made by this client, not just proxy connections.
+// If you need host-scoped certificate selection, consider using a custom transport with
+// tls.Config.GetClientCertificate instead.
 func WithTLSClientCertificate(cert tls.Certificate) HTTPOption {
 	return func(c *httpClientOption) {
 		c.tlsClientCertificates = append(c.tlsClientCertificates, cert)
 	}
 }
 
-// WithTLSClientCertificateFromFile loads a TLS client certificate and key from files
-// for mTLS authentication. This is a convenience function that wraps WithTLSClientCertificate.
+// WithTLSClientCertificateFromFile loads a TLS client certificate and key from files.
+// This is a convenience function that wraps WithTLSClientCertificate.
+// See WithTLSClientCertificate for important notes about certificate scope.
 func WithTLSClientCertificateFromFile(certFile, keyFile string) (HTTPOption, error) {
 	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
 	if err != nil {

--- a/common_client_test.go
+++ b/common_client_test.go
@@ -1,12 +1,15 @@
 package scaleset
 
 import (
+	"crypto/tls"
 	"encoding/json"
 	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -292,5 +295,69 @@ func TestWithRetryableHTTPClient(t *testing.T) {
 		}
 		// Should have tried 1 initial + 1 retry = 2 times total
 		assert.Equal(t, 2, attemptCount)
+	})
+}
+
+func TestWithTLSClientCertificate(t *testing.T) {
+	t.Run("applies client certificate to transport", func(t *testing.T) {
+		cert, err := tls.LoadX509KeyPair("testdata/leaf.crt", "testdata/leaf.key")
+		require.NoError(t, err)
+
+		opts := defaultHTTPClientOption()
+		WithTLSClientCertificate(cert)(&opts)
+
+		assert.Len(t, opts.tlsClientCertificates, 1)
+
+		client, err := opts.newRetryableHTTPClient()
+		require.NoError(t, err)
+
+		transport, ok := client.HTTPClient.Transport.(*http.Transport)
+		require.True(t, ok)
+		assert.Len(t, transport.TLSClientConfig.Certificates, 1)
+	})
+
+	t.Run("allows multiple certificates", func(t *testing.T) {
+		cert, err := tls.LoadX509KeyPair("testdata/leaf.crt", "testdata/leaf.key")
+		require.NoError(t, err)
+
+		opts := defaultHTTPClientOption()
+		WithTLSClientCertificate(cert)(&opts)
+		WithTLSClientCertificate(cert)(&opts)
+
+		assert.Len(t, opts.tlsClientCertificates, 2)
+	})
+}
+
+func TestWithTLSClientCertificateFromFile(t *testing.T) {
+	t.Run("loads certificate from files", func(t *testing.T) {
+		certFile := "testdata/leaf.crt"
+		keyFile := "testdata/leaf.key"
+
+		opt, err := WithTLSClientCertificateFromFile(certFile, keyFile)
+		require.NoError(t, err)
+
+		opts := defaultHTTPClientOption()
+		opt(&opts)
+
+		assert.Len(t, opts.tlsClientCertificates, 1)
+	})
+
+	t.Run("returns error for non-existent files", func(t *testing.T) {
+		_, err := WithTLSClientCertificateFromFile("nonexistent.crt", "nonexistent.key")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to load client certificate")
+	})
+
+	t.Run("returns error for invalid certificate", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		certFile := filepath.Join(tmpDir, "invalid.crt")
+		keyFile := filepath.Join(tmpDir, "invalid.key")
+
+		require.NoError(t, os.WriteFile(certFile, []byte("not a cert"), 0600))
+		require.NoError(t, os.WriteFile(keyFile, []byte("not a key"), 0600))
+
+		_, err := WithTLSClientCertificateFromFile(certFile, keyFile)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to load client certificate")
 	})
 }


### PR DESCRIPTION
## Summary

- Adds `WithTLSClientCertificate(cert tls.Certificate)` HTTPOption to configure TLS client certificates for mTLS authentication
- Adds `WithTLSClientCertificateFromFile(certFile, keyFile string)` convenience function to load certificates from files
- This enables mTLS authentication when connecting through proxies that require client certificate verification (e.g., corporate mTLS proxies like Kraken)

## Use Case

Enterprise environments often use mTLS proxies that require clients to present certificates for authentication. This change enables the scaleset library to work in such environments by allowing users to configure client certificates.

## Example Usage

```go
// Using certificate directly
cert, err := tls.LoadX509KeyPair("client.crt", "client.key")
if err != nil {
    return err
}
client, err := scaleset.NewClient(
    configURL,
    creds,
    scaleset.WithTLSClientCertificate(cert),
    scaleset.WithProxy(proxyFunc),
)

// Using convenience function
tlsOpt, err := scaleset.WithTLSClientCertificateFromFile("client.crt", "client.key")
if err != nil {
    return err
}
client, err := scaleset.NewClient(
    configURL,
    creds,
    tlsOpt,
    scaleset.WithProxy(proxyFunc),
)
```

## Test plan

- [x] Added unit tests for `WithTLSClientCertificate`
- [x] Added unit tests for `WithTLSClientCertificateFromFile`
- [x] Verified error handling for invalid certificates
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)