### PR TITLE
feat(listener): add RecordJobAvailable metrics hook

### DIFF
--- a/listener/listener.go
+++ b/listener/listener.go
@@ -63,6 +63,7 @@ type Client interface {
 // of the listener and the scaleset service.
 type MetricsRecorder interface {
 	RecordStatistics(statistics *scaleset.RunnerScaleSetStatistic)
+	RecordJobAvailable(msg *scaleset.JobAvailable)
 	RecordJobStarted(msg *scaleset.JobStarted)
 	RecordJobCompleted(msg *scaleset.JobCompleted)
 	RecordDesiredRunners(count int)
@@ -71,6 +72,7 @@ type MetricsRecorder interface {
 type discardMetricsRecorder struct{}
 
 func (d *discardMetricsRecorder) RecordStatistics(statistics *scaleset.RunnerScaleSetStatistic) {}
+func (d *discardMetricsRecorder) RecordJobAvailable(msg *scaleset.JobAvailable)                 {}
 func (d *discardMetricsRecorder) RecordJobStarted(msg *scaleset.JobStarted)                     {}
 func (d *discardMetricsRecorder) RecordJobCompleted(msg *scaleset.JobCompleted)                 {}
 func (d *discardMetricsRecorder) RecordDesiredRunners(count int)                                {}
@@ -212,6 +214,10 @@ func (l *Listener) handleMessage(ctx context.Context, handler Scaler, msg *scale
 	}
 
 	if len(msg.JobAvailableMessages) > 0 {
+		for _, jobAvailable := range msg.JobAvailableMessages {
+			l.metricsRecorder.RecordJobAvailable(jobAvailable)
+		}
+
 		if err := l.acquireAvailableJobs(ctx, msg.JobAvailableMessages); err != nil {
 			return fmt.Errorf("failed to acquire available jobs: %w", err)
 		}

--- a/listener/mocks_test.go
+++ b/listener/mocks_test.go
@@ -388,6 +388,46 @@ func (_c *MockMetricsRecorder_RecordJobCompleted_Call) RunAndReturn(run func(msg
 	return _c
 }
 
+// RecordJobAvailable provides a mock function for the type MockMetricsRecorder
+func (_mock *MockMetricsRecorder) RecordJobAvailable(msg *scaleset.JobAvailable) {
+	_mock.Called(msg)
+	return
+}
+
+// MockMetricsRecorder_RecordJobAvailable_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RecordJobAvailable'
+type MockMetricsRecorder_RecordJobAvailable_Call struct {
+	*mock.Call
+}
+
+// RecordJobAvailable is a helper method to define mock.On call
+//   - msg *scaleset.JobAvailable
+func (_e *MockMetricsRecorder_Expecter) RecordJobAvailable(msg interface{}) *MockMetricsRecorder_RecordJobAvailable_Call {
+	return &MockMetricsRecorder_RecordJobAvailable_Call{Call: _e.mock.On("RecordJobAvailable", msg)}
+}
+
+func (_c *MockMetricsRecorder_RecordJobAvailable_Call) Run(run func(msg *scaleset.JobAvailable)) *MockMetricsRecorder_RecordJobAvailable_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 *scaleset.JobAvailable
+		if args[0] != nil {
+			arg0 = args[0].(*scaleset.JobAvailable)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockMetricsRecorder_RecordJobAvailable_Call) Return() *MockMetricsRecorder_RecordJobAvailable_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *MockMetricsRecorder_RecordJobAvailable_Call) RunAndReturn(run func(msg *scaleset.JobAvailable)) *MockMetricsRecorder_RecordJobAvailable_Call {
+	_c.Run(run)
+	return _c
+}
+
 // RecordJobStarted provides a mock function for the type MockMetricsRecorder
 func (_mock *MockMetricsRecorder) RecordJobStarted(msg *scaleset.JobStarted) {
 	_mock.Called(msg)


### PR DESCRIPTION
## Summary
- Adds `RecordJobAvailable` to the `MetricsRecorder` interface
- Invokes the hook when `JobAvailable` messages are received, before jobs are acquired

This enables downstream metrics implementations (e.g. actions-runner-controller) to accurately track `gha_job_queue_duration_seconds`, since GitHub does not populate `QueueTime` on `JobStarted` messages.

## Test plan
- [ ] CI passes
- [ ] Paired with actions/actions-runner-controller PR adding the histogram


Made with [Cursor](https://cursor.com)