### PR TITLE
feat: pluggable JWT signing for GitHub App auth (KMS/HSM support)

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,12 +142,41 @@ If you are not a Go developer, you can still:
 
 ## Authentication
 
-Two options:
+Three options:
 
 1. **GitHub App (preferred):** Stronger scoping & rotation. Provide: `ClientID`, `InstallationID`, `PrivateKey`.
-2. **PAT (personal access token):** Simpler but broader scoped.
+2. **GitHub App with custom JWT signing:** For KMS/HSM-backed keys where private key material cannot be in memory. Provide a `JWTProvider` implementation.
+3. **PAT (personal access token):** Simpler but broader scoped.
 
 The client automatically exchanges credentials for a registration token + admin token behind the scenes and refreshes them before expiry.
+
+### Custom JWT Signing (KMS/HSM)
+
+For organizations that require private key material to stay within a KMS or HSM boundary:
+
+```go
+// Using a crypto.Signer (AWS KMS, GCP Cloud KMS, Azure Key Vault, etc.)
+provider := &scaleset.SignerJWTProvider{
+    ClientID: "Iv1.abc123",
+    Signer:   myKMSSigner, // any crypto.Signer with an RSA key
+}
+
+client, err := scaleset.NewClientWithJWTProvider(
+    scaleset.ClientWithJWTProviderConfig{
+        GitHubConfigURL: "https://github.com/my-org",
+        InstallationID:  12345,
+    },
+    provider,
+)
+```
+
+Or wrap any function that returns a signed JWT:
+
+```go
+provider := scaleset.JWTProviderFunc(func(ctx context.Context) (string, error) {
+    return getJWTFromExternalService(ctx)
+})
+```
 
 You can find more details on required permissions in the [GitHub Docs](https://docs.github.com/en/actions/tutorials/use-actions-runner-controller/authenticate-to-the-api).
 
@@ -175,6 +204,7 @@ Assigning more than one label to a scale set is supported on **GHES 3.18 and lat
 ## Security Notes
 
 - Always prefer GitHub App credentials; rotate PATs if you must use them.
+- Use `SignerJWTProvider` or `JWTProviderFunc` to keep private key material in a KMS/HSM.
 - Treat JIT configs as secrets until consumed.
 
 ---

--- a/client.go
+++ b/client.go
@@ -104,27 +104,29 @@ func (a *GitHubAppAuth) Validate() error {
 }
 
 type actionsAuth struct {
-	// app is the GitHub app credentials
-	app *GitHubAppAuth
-	// GitHub PAT
+	// token is a GitHub PAT (mutually exclusive with jwtProvider).
 	token string
+	// jwtProvider creates JWTs for GitHub App auth.
+	jwtProvider JWTProvider
+	// installationID is the GitHub App installation ID (used with jwtProvider).
+	installationID int64
 }
 
 // validate does the basic validation check, ensuring that
-// either GitHub App credentials or a personal access token is provided.
-// If GitHub App credentials are provided, it further validates the credentials.
+// either GitHub App credentials (a JWT provider with an installation ID)
+// or a personal access token is provided.
 //
 // This method does not validate the credentials against GitHub, so it does not
 // check if the credentials are correct or have the necessary permissions.
 func (a actionsAuth) validate() error {
-	if a.token == "" && a.app == nil {
+	if a.token == "" && a.jwtProvider == nil {
 		return fmt.Errorf("either GitHub App credentials or personal access token is required")
 	}
-	if a.token != "" && a.app != nil {
+	if a.token != "" && a.jwtProvider != nil {
 		return fmt.Errorf("cannot provide both GitHub App credentials and personal access token")
 	}
-	if a.app != nil {
-		return a.app.Validate()
+	if a.jwtProvider != nil && a.installationID == 0 {
+		return fmt.Errorf("app installation ID is required")
 	}
 	return nil
 }
@@ -163,11 +165,21 @@ type ClientWithGitHubAppConfig struct {
 
 // NewClientWithGitHubApp creates a new Client using GitHub App credentials.
 func NewClientWithGitHubApp(config ClientWithGitHubAppConfig, options ...HTTPOption) (*Client, error) {
+	if err := config.GitHubAppAuth.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid credentials: %w", err)
+	}
+
+	provider, err := newPEMJWTProvider(config.GitHubAppAuth.ClientID, config.GitHubAppAuth.PrivateKey)
+	if err != nil {
+		return nil, fmt.Errorf("invalid credentials: %w", err)
+	}
+
 	return newClient(
 		config.SystemInfo,
 		config.GitHubConfigURL,
 		actionsAuth{
-			app: &config.GitHubAppAuth,
+			jwtProvider:    provider,
+			installationID: config.GitHubAppAuth.InstallationID,
 		},
 		options...,
 	)
@@ -187,6 +199,35 @@ func NewClientWithPersonalAccessToken(config NewClientWithPersonalAccessTokenCon
 		config.GitHubConfigURL,
 		actionsAuth{
 			token: config.PersonalAccessToken,
+		},
+		options...,
+	)
+}
+
+// ClientWithJWTProviderConfig contains the configuration for creating a new Client
+// using a custom JWTProvider for GitHub App authentication.
+type ClientWithJWTProviderConfig struct {
+	GitHubConfigURL string
+	InstallationID  int64
+	SystemInfo      SystemInfo
+}
+
+// NewClientWithJWTProvider creates a new Client using a custom JWTProvider for GitHub App
+// authentication. This enables KMS-backed signing where private key material never
+// leaves the secure boundary.
+func NewClientWithJWTProvider(config ClientWithJWTProviderConfig, provider JWTProvider, options ...HTTPOption) (*Client, error) {
+	if provider == nil {
+		return nil, fmt.Errorf("JWT provider is required")
+	}
+	if config.InstallationID == 0 {
+		return nil, fmt.Errorf("installation ID is required")
+	}
+	return newClient(
+		config.SystemInfo,
+		config.GitHubConfigURL,
+		actionsAuth{
+			jwtProvider:    provider,
+			installationID: config.InstallationID,
 		},
 		options...,
 	)
@@ -818,7 +859,7 @@ func (c *Client) getRunnerRegistrationToken(ctx context.Context) (*registrationT
 	if c.creds.token != "" {
 		bearerToken = fmt.Sprintf("Bearer %v", c.creds.token)
 	} else {
-		accessToken, err := c.fetchAccessToken(ctx, c.creds.app)
+		accessToken, err := c.fetchAccessToken(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch access token: %w", err)
 		}
@@ -855,13 +896,13 @@ type accessToken struct {
 	ExpiresAt time.Time `json:"expires_at"`
 }
 
-func (c *Client) fetchAccessToken(ctx context.Context, creds *GitHubAppAuth) (*accessToken, error) {
-	accessTokenJWT, err := createJWTForGitHubApp(creds)
+func (c *Client) fetchAccessToken(ctx context.Context) (*accessToken, error) {
+	accessTokenJWT, err := c.creds.jwtProvider.Token(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create JWT for GitHub app: %w", err)
+		return nil, fmt.Errorf("failed to get JWT for GitHub App auth: %w", err)
 	}
 
-	path := fmt.Sprintf("/app/installations/%v/access_tokens", creds.InstallationID)
+	path := fmt.Sprintf("/app/installations/%v/access_tokens", c.creds.installationID)
 	req, err := c.newGitHubAPIRequest(ctx, http.MethodPost, path, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create new GitHub API request: %w", err)
@@ -993,30 +1034,6 @@ func createRegistrationTokenPath(config *gitHubConfig) (string, error) {
 	default:
 		return "", fmt.Errorf("unknown scope for config url: %s", config.configURL)
 	}
-}
-
-func createJWTForGitHubApp(appAuth *GitHubAppAuth) (string, error) {
-	// Encode as JWT
-	// See https://docs.github.com/en/developers/apps/building-github-apps/authenticating-with-github-apps#authenticating-as-a-github-app
-
-	// Going back in time a bit helps with clock skew.
-	issuedAt := time.Now().Add(-60 * time.Second)
-	// Max expiration date is 10 minutes.
-	expiresAt := issuedAt.Add(9 * time.Minute)
-	claims := &jwt.RegisteredClaims{
-		IssuedAt:  jwt.NewNumericDate(issuedAt),
-		ExpiresAt: jwt.NewNumericDate(expiresAt),
-		Issuer:    appAuth.ClientID,
-	}
-
-	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
-
-	privateKey, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(appAuth.PrivateKey))
-	if err != nil {
-		return "", fmt.Errorf("failed to parse RSA private key from PEM: %w", err)
-	}
-
-	return token.SignedString(privateKey)
 }
 
 // Returns slice of body without utf-8 byte order mark.

--- a/client.go
+++ b/client.go
@@ -16,7 +16,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/hashicorp/go-retryablehttp"
 )
 

--- a/client_test.go
+++ b/client_test.go
@@ -19,7 +19,7 @@ import (
 	"time"
 
 	"github.com/actions/scaleset/internal/testserver"
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/client_test.go
+++ b/client_test.go
@@ -120,7 +120,7 @@ func TestNewClientWithPersonalAccessToken(t *testing.T) {
 		require.NotNil(t, client)
 
 		assert.Equal(t, "ghp_test_token", client.creds.token)
-		assert.Nil(t, client.creds.app)
+		assert.Nil(t, client.creds.jwtProvider)
 		assert.Equal(t, "my-org", client.config.organization)
 		assert.Equal(t, "my-repo", client.config.repository)
 		assert.Equal(t, testSystemInfo, client.SystemInfo())
@@ -156,10 +156,8 @@ func TestNewClientWithGitHubApp(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, client)
 
-		require.NotNil(t, client.creds.app)
-		assert.Equal(t, "12345", client.creds.app.ClientID)
-		assert.EqualValues(t, 67890, client.creds.app.InstallationID)
-		assert.Equal(t, samplePrivateKey, client.creds.app.PrivateKey)
+		require.NotNil(t, client.creds.jwtProvider)
+		assert.EqualValues(t, 67890, client.creds.installationID)
 		assert.Equal(t, "", client.creds.token)
 		assert.Equal(t, "my-org", client.config.organization)
 		assert.Equal(t, "my-repo", client.config.repository)
@@ -218,6 +216,22 @@ func TestNewClientWithGitHubApp(t *testing.T) {
 			assert.Contains(t, err.Error(), "app private key is required")
 		})
 	})
+
+	t.Run("returns error for an invalid private key", func(t *testing.T) {
+		client, err := NewClientWithGitHubApp(ClientWithGitHubAppConfig{
+			GitHubConfigURL: "https://github.com/my-org/my-repo",
+			GitHubAppAuth: GitHubAppAuth{
+				ClientID:       "12345",
+				InstallationID: 67890,
+				PrivateKey:     "not a private key",
+			},
+			SystemInfo: testSystemInfo,
+		})
+		require.Error(t, err)
+		assert.Nil(t, client)
+		assert.Contains(t, err.Error(), "invalid credentials")
+		assert.Contains(t, err.Error(), "failed to parse RSA private key from PEM")
+	})
 }
 
 func TestNewClientWithBothTokenAndGitHubApp(t *testing.T) {
@@ -226,12 +240,9 @@ func TestNewClientWithBothTokenAndGitHubApp(t *testing.T) {
 			testSystemInfo,
 			"https://github.com/my-org/my-repo",
 			actionsAuth{
-				token: "ghp_test_token",
-				app: &GitHubAppAuth{
-					ClientID:       "12345",
-					InstallationID: 67890,
-					PrivateKey:     samplePrivateKey,
-				},
+				token:          "ghp_test_token",
+				jwtProvider:    JWTProviderFunc(func(context.Context) (string, error) { return "jwt", nil }),
+				installationID: 67890,
 			},
 		)
 
@@ -1551,6 +1562,93 @@ func startNewTLSTestServer(t *testing.T, certPath, keyPath string, handler http.
 	server.StartTLS()
 
 	return server
+}
+
+func TestNewClientWithJWTProvider(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("full flow with custom JWT provider", func(t *testing.T) {
+		var capturedAuthHeader string
+		server := testserver.New(t, nil,
+			testserver.WithInstallationAccessTokenHandler(func(w http.ResponseWriter, r *http.Request) {
+				capturedAuthHeader = r.Header.Get("Authorization")
+				w.WriteHeader(http.StatusCreated)
+				w.Write([]byte(`{"token":"ghs_test_installation_token","expires_at":"2099-01-01T00:00:00Z"}`))
+			}),
+		)
+
+		provider := JWTProviderFunc(func(_ context.Context) (string, error) {
+			return "my-custom-jwt", nil
+		})
+
+		client, err := NewClientWithJWTProvider(
+			ClientWithJWTProviderConfig{
+				GitHubConfigURL: server.ConfigURLForOrg("my-org"),
+				InstallationID:  42,
+				SystemInfo:      testSystemInfo,
+			},
+			provider,
+		)
+		require.NoError(t, err)
+
+		// Trigger the full auth flow by making a request that needs authentication
+		req, err := client.newActionsServiceRequest(ctx, http.MethodGet, "/test", nil)
+		require.NoError(t, err)
+		assert.NotNil(t, req)
+
+		// Verify our custom JWT was used in the installation access token request
+		assert.Equal(t, "Bearer my-custom-jwt", capturedAuthHeader)
+	})
+
+	t.Run("provider error propagates", func(t *testing.T) {
+		server := testserver.New(t, nil)
+
+		expectedErr := errors.New("kms unavailable")
+		provider := JWTProviderFunc(func(_ context.Context) (string, error) {
+			return "", expectedErr
+		})
+
+		client, err := NewClientWithJWTProvider(
+			ClientWithJWTProviderConfig{
+				GitHubConfigURL: server.ConfigURLForOrg("my-org"),
+				InstallationID:  42,
+				SystemInfo:      testSystemInfo,
+			},
+			provider,
+		)
+		require.NoError(t, err)
+
+		_, err = client.newActionsServiceRequest(ctx, http.MethodGet, "/test", nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "kms unavailable")
+	})
+
+	t.Run("nil provider returns error", func(t *testing.T) {
+		_, err := NewClientWithJWTProvider(
+			ClientWithJWTProviderConfig{
+				GitHubConfigURL: "https://github.com/my-org",
+				InstallationID:  42,
+			},
+			nil,
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "JWT provider is required")
+	})
+
+	t.Run("zero installation ID returns error", func(t *testing.T) {
+		provider := JWTProviderFunc(func(_ context.Context) (string, error) {
+			return "jwt", nil
+		})
+		_, err := NewClientWithJWTProvider(
+			ClientWithJWTProviderConfig{
+				GitHubConfigURL: "https://github.com/my-org",
+				InstallationID:  0,
+			},
+			provider,
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "installation ID is required")
+	})
 }
 
 const samplePrivateKey = `-----BEGIN PRIVATE KEY-----

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.3
 
 require (
 	github.com/docker/docker v28.5.2+incompatible
-	github.com/golang-jwt/jwt/v4 v4.5.2
+	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/go-github/v79 v79.0.0
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-retryablehttp v0.7.8

--- a/go.sum
+++ b/go.sum
@@ -252,8 +252,8 @@ github.com/godoc-lint/godoc-lint v0.11.2/go.mod h1:iVpGdL1JCikNH2gGeAn3Hh+AgN5Gx
 github.com/gofrs/flock v0.13.0 h1:95JolYOvGMqeH31+FC7D2+uULf6mG61mEZ/A8dRYMzw=
 github.com/gofrs/flock v0.13.0/go.mod h1:jxeyy9R1auM5S6JYDBhDt+E2TCo7DkratH4Pgi8P+Z0=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
-github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=
-github.com/golang-jwt/jwt/v4 v4.5.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/internal/testserver/server.go
+++ b/internal/testserver/server.go
@@ -39,6 +39,12 @@ func NewUnstarted(t testing.TB, handler http.Handler, options ...actionsServerOp
 	}
 
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// handle fetchAccessToken (GitHub App installation access token)
+		if strings.HasSuffix(r.URL.Path, "/access_tokens") && strings.Contains(r.URL.Path, "/app/installations/") {
+			server.installationAccessTokenHandler(w, r)
+			return
+		}
+
 		// handle getRunnerRegistrationToken
 		if strings.HasSuffix(r.URL.Path, "/runners/registration-token") {
 			server.runnerRegistrationTokenHandler(w, r)
@@ -79,15 +85,29 @@ func WithActionsRegistrationTokenHandler(h http.HandlerFunc) actionsServerOption
 	}
 }
 
+func WithInstallationAccessTokenHandler(h http.HandlerFunc) actionsServerOption {
+	return func(s *actionsServer) {
+		s.installationAccessTokenHandler = h
+	}
+}
+
 type actionsServer struct {
 	*httptest.Server
 
 	token                          string
 	runnerRegistrationTokenHandler http.HandlerFunc
 	actionRegistrationTokenHandler http.HandlerFunc
+	installationAccessTokenHandler http.HandlerFunc
 }
 
 func (s *actionsServer) setDefaults(t testing.TB) {
+	if s.installationAccessTokenHandler == nil {
+		s.installationAccessTokenHandler = func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusCreated)
+			w.Write([]byte(`{"token":"ghs_installation_token","expires_at":"2099-01-01T00:00:00Z"}`))
+		}
+	}
+
 	if s.runnerRegistrationTokenHandler == nil {
 		s.runnerRegistrationTokenHandler = func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusCreated)

--- a/internal/testserver/server.go
+++ b/internal/testserver/server.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/require"
 )
 

--- a/jwt_provider.go
+++ b/jwt_provider.go
@@ -1,0 +1,120 @@
+package scaleset
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"fmt"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// JWTProvider creates short-lived JWTs for GitHub App authentication.
+// Implementations must be safe for concurrent use.
+//
+// The returned JWT must be RS256-signed with iss (Client ID), iat, and exp claims.
+// See https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-json-web-token-jwt-for-a-github-app
+type JWTProvider interface {
+	Token(ctx context.Context) (string, error)
+}
+
+// SignerJWTProvider creates GitHub App JWTs using a [crypto.Signer].
+// This enables KMS-backed keys (AWS KMS, GCP Cloud KMS, Azure Key Vault)
+// where private key material never leaves the secure boundary.
+// The Signer's Public() method must return *[crypto/rsa.PublicKey].
+type SignerJWTProvider struct {
+	ClientID string
+	Signer   crypto.Signer
+}
+
+// Token creates a signed JWT for GitHub App authentication.
+//
+// It uses the JWT library to assemble the token, then signs the resulting
+// digest through the crypto.Signer because SignedString requires a concrete
+// *rsa.PrivateKey.
+func (p *SignerJWTProvider) Token(ctx context.Context) (string, error) {
+	if p == nil || p.Signer == nil {
+		return "", fmt.Errorf("signer is required")
+	}
+	if p.ClientID == "" {
+		return "", fmt.Errorf("client ID is required")
+	}
+	if err := ctx.Err(); err != nil {
+		return "", fmt.Errorf("sign app JWT: %w", err)
+	}
+
+	publicKey := p.Signer.Public()
+	if _, ok := publicKey.(*rsa.PublicKey); !ok {
+		return "", fmt.Errorf("signer public key must be *rsa.PublicKey, got %T", publicKey)
+	}
+
+	token := newGitHubAppJWT(p.ClientID)
+	signingInput, err := token.SigningString()
+	if err != nil {
+		return "", fmt.Errorf("create app JWT signing input: %w", err)
+	}
+
+	digest := sha256.Sum256([]byte(signingInput))
+	sig, err := p.Signer.Sign(rand.Reader, digest[:], crypto.SHA256)
+	if err != nil {
+		return "", fmt.Errorf("sign app JWT: %w", err)
+	}
+	return signingInput + "." + token.EncodeSegment(sig), nil
+}
+
+// pemJWTProvider signs JWTs using a PEM-encoded RSA private key.
+type pemJWTProvider struct {
+	clientID   string
+	privateKey *rsa.PrivateKey
+}
+
+// newPEMJWTProvider creates a JWTProvider from a PEM-encoded RSA private key string.
+func newPEMJWTProvider(clientID, pemKey string) (*pemJWTProvider, error) {
+	privateKey, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(pemKey))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse RSA private key from PEM: %w", err)
+	}
+	return &pemJWTProvider{
+		clientID:   clientID,
+		privateKey: privateKey,
+	}, nil
+}
+
+func (p *pemJWTProvider) Token(ctx context.Context) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", fmt.Errorf("sign app JWT: %w", err)
+	}
+	return newGitHubAppJWT(p.clientID).SignedString(p.privateKey)
+}
+
+func newGitHubAppJWT(clientID string) *jwt.Token {
+	issuedAt := time.Now().Add(-time.Minute)
+	expiresAt := issuedAt.Add(9 * time.Minute)
+
+	return jwt.NewWithClaims(jwt.SigningMethodRS256, &jwt.RegisteredClaims{
+		IssuedAt:  jwt.NewNumericDate(issuedAt),
+		ExpiresAt: jwt.NewNumericDate(expiresAt),
+		Issuer:    clientID,
+	})
+}
+
+// Ensure both providers satisfy the interface at compile time.
+var (
+	_ JWTProvider = (*SignerJWTProvider)(nil)
+	_ JWTProvider = (*pemJWTProvider)(nil)
+	_ JWTProvider = JWTProviderFunc(nil)
+)
+
+// JWTProviderFunc adapts a function to a [JWTProvider].
+type JWTProviderFunc func(ctx context.Context) (string, error)
+
+// Token calls f with ctx.
+func (f JWTProviderFunc) Token(ctx context.Context) (string, error) {
+	if f == nil {
+		return "", fmt.Errorf("JWT provider function is required")
+	}
+	return f(ctx)
+}

--- a/jwt_provider_test.go
+++ b/jwt_provider_test.go
@@ -1,0 +1,169 @@
+package scaleset
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func generateTestKey(t *testing.T) *rsa.PrivateKey {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	return key
+}
+
+func pemEncodeKey(key *rsa.PrivateKey) string {
+	return string(pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	}))
+}
+
+func parseTestJWT(t *testing.T, provider JWTProvider, key *rsa.PublicKey) *jwt.RegisteredClaims {
+	t.Helper()
+	claims := &jwt.RegisteredClaims{}
+
+	tokenString, err := provider.Token(context.Background())
+	require.NoError(t, err)
+
+	token, err := jwt.ParseWithClaims(
+		tokenString,
+		claims,
+		func(_ *jwt.Token) (any, error) { return key, nil },
+		jwt.WithValidMethods([]string{jwt.SigningMethodRS256.Alg()}),
+	)
+	require.NoError(t, err)
+	require.True(t, token.Valid)
+
+	return claims
+}
+
+func TestJWTProviders(t *testing.T) {
+	const clientID = "Iv1.test123"
+	key := generateTestKey(t)
+	pemProvider, err := newPEMJWTProvider(clientID, pemEncodeKey(key))
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		provider JWTProvider
+	}{
+		{name: "PEM private key", provider: pemProvider},
+		{name: "crypto signer", provider: &SignerJWTProvider{ClientID: clientID, Signer: key}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			claims := parseTestJWT(t, tt.provider, &key.PublicKey)
+
+			assert.Equal(t, clientID, claims.Issuer)
+			require.NotNil(t, claims.IssuedAt)
+			require.NotNil(t, claims.ExpiresAt)
+			assert.WithinDuration(t, time.Now().Add(-time.Minute), claims.IssuedAt.Time, 2*time.Second)
+			assert.Equal(t, 9*time.Minute, claims.ExpiresAt.Sub(claims.IssuedAt.Time))
+
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			_, err := tt.provider.Token(ctx)
+			require.ErrorIs(t, err, context.Canceled)
+		})
+	}
+}
+
+func TestPEMJWTProviderInvalidPEM(t *testing.T) {
+	_, err := newPEMJWTProvider("test", "not-a-valid-pem")
+	require.Error(t, err)
+}
+
+type testSigner struct {
+	publicKey crypto.PublicKey
+	err       error
+}
+
+func (s *testSigner) Public() crypto.PublicKey {
+	return s.publicKey
+}
+
+func (s *testSigner) Sign(_ io.Reader, _ []byte, _ crypto.SignerOpts) ([]byte, error) {
+	return nil, s.err
+}
+
+func TestSignerJWTProviderValidation(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider *SignerJWTProvider
+		wantErr  string
+	}{
+		{name: "nil provider", wantErr: "signer is required"},
+		{name: "missing signer", provider: &SignerJWTProvider{ClientID: "test"}, wantErr: "signer is required"},
+		{
+			name:     "missing client ID",
+			provider: &SignerJWTProvider{Signer: &testSigner{publicKey: &rsa.PublicKey{}}},
+			wantErr:  "client ID is required",
+		},
+		{
+			name:     "non-RSA signer",
+			provider: &SignerJWTProvider{ClientID: "test", Signer: &testSigner{publicKey: "not an RSA key"}},
+			wantErr:  "signer public key must be *rsa.PublicKey",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.provider.Token(context.Background())
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestSignerJWTProviderSigningError(t *testing.T) {
+	expectedErr := errors.New("KMS unavailable")
+	provider := &SignerJWTProvider{
+		ClientID: "test",
+		Signer: &testSigner{
+			publicKey: &rsa.PublicKey{},
+			err:       expectedErr,
+		},
+	}
+
+	_, err := provider.Token(context.Background())
+	require.ErrorIs(t, err, expectedErr)
+}
+
+func TestJWTProviderFunc(t *testing.T) {
+	t.Run("returns the function result", func(t *testing.T) {
+		provider := JWTProviderFunc(func(_ context.Context) (string, error) {
+			return "test-jwt-token", nil
+		})
+
+		token, err := provider.Token(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, "test-jwt-token", token)
+	})
+
+	t.Run("propagates errors", func(t *testing.T) {
+		expectedErr := errors.New("KMS unavailable")
+		provider := JWTProviderFunc(func(_ context.Context) (string, error) {
+			return "", expectedErr
+		})
+
+		_, err := provider.Token(context.Background())
+		require.ErrorIs(t, err, expectedErr)
+	})
+
+	t.Run("rejects a nil function", func(t *testing.T) {
+		var provider JWTProviderFunc
+		_, err := provider.Token(context.Background())
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
## What

Adds a `JWTProvider` interface so GitHub App JWTs can be signed outside the client, enabling KMS-backed App keys (AWS KMS, GCP Cloud KMS, Azure Key Vault, PKCS#11 HSMs) where the private key material never leaves the secure boundary. Existing constructors and behavior are unchanged.

```go
// The new seam: anything that can produce a GitHub App JWT.
type JWTProvider interface {
	Token(ctx context.Context) (string, error)
}
```

Three ways in:

- **`NewClientWithGitHubApp`** — unchanged public API. The PEM signing path just becomes an internal `pemJWTProvider`; same claims, same errors.
- **`NewClientWithJWTProvider`** — new constructor accepting any `JWTProvider` plus the installation ID.
- **`SignerJWTProvider`** — adapts any `crypto.Signer` whose `Public()` is `*rsa.PublicKey`. This is the KMS bridge: an `awskms`/`cloudkms`/`keyvault` signer plugs straight in.

Plus `JWTProviderFunc`, a function type implementing the interface (`http.HandlerFunc` style).

## Why

GitHub App private keys are long-lived, org-wide credentials. Today the client requires the PEM in memory, which forces operators to distribute and rotate raw key material through their config/secret plumbing. Cloud KMS services expose RSA keys as `crypto.Signer` without ever releasing the key — but the client has no seam to accept one.

We run this in production against GitHub Enterprise Cloud with data residency (GHEC DR) with the App key held in AWS KMS: the client signs App JWTs via `SignerJWTProvider`, and the raw key exists nowhere in our infrastructure.

## Why `SignerJWTProvider` signs through the `crypto.Signer`

`jwt/v5`'s `SignedString` requires a concrete `*rsa.PrivateKey`, so it cannot drive a remote signer — the very thing `crypto.Signer` exists to abstract. `SignerJWTProvider` therefore lets jwt/v5 build the token (`SigningString()` with `RegisteredClaims`: `iss` = Client ID, `iat` backdated 1m, `exp` = +9m, matching the existing PEM path and GitHub's 10-minute cap), then SHA-256s the signing input and signs the digest through the `Signer`, encoding the signature with the library's own `EncodeSegment`. Both providers share one claims builder, so the PEM and Signer paths cannot drift. Output is a standard RS256 JWT; the tests run both providers through identical round-trip verification with `jwt.WithValidMethods` pinning RS256.

One caveat worth stating: `crypto.Signer.Sign` takes no `context.Context`, so cancellation is checked before signing but cannot propagate into the signing call itself. Implementations needing that (e.g. per-request KMS timeouts) can wrap their signer or implement `JWTProvider` directly.

## Commits

1. **build: upgrade golang-jwt/jwt v4 to v5** — prerequisite; v4 is in maintenance and v5 is where `RegisteredClaims`/parser options live. Minimal footprint: one `require` line swaps and `go.sum` carries only the v5 hashes. (`go mod tidy` is deliberately not run — it fails on `main` today from the pre-existing monolithic-vs-split genproto ambiguity in the docker example's test closure, unrelated to this change; happy to file that separately.)
2. **feat: add JWTProvider interface for pluggable GitHub App auth** — the feature as described above. `actionsAuth` holds `jwtProvider` + `installationID` instead of the `GitHubAppAuth` struct; `validate()` semantics, error messages, and the `invalid credentials` wrapping are preserved, and the new validation tests from #102 are adapted to the provider field.

(Currently stacked on the runtime-generated-test-certs PR so CI can run green — `main`'s committed certs expired 2026-07-13; rebases to just the two commits above once that lands.)

## Testing

`go build ./...` and `go test -race ./...` green across the repo, plus gofmt/golangci-lint/mockery-diff clean. New coverage in `jwt_provider_test.go`: a table runs the PEM and Signer providers through identical round-trip verification (RS256 pinned via `jwt.WithValidMethods`, claim timing asserted, context cancellation honored), signer error propagation, nil/missing-field validation, non-RSA signer rejection, invalid PEM, and `JWTProviderFunc` passthrough/error propagation. `client_test.go` adds an invalid-private-key case asserting the `invalid credentials` wrapping.

## Compatibility

- No exported API removed or changed; `NewClientWithGitHubApp` callers are unaffected.
- `GitHubAppAuth` and its `Validate()` remain as-is.
- Error messages and wrapping preserved so existing assertions/telemetry keyed on them keep working.

Closes #112 