### PR TITLE
feat: typed rate-limit errors carrying the server's Retry-After hint

### DIFF
--- a/client.go
+++ b/client.go
@@ -946,10 +946,6 @@ func (c *Client) getActionsServiceAdminConnectionRequest(req *http.Request) (*ac
 
 		return retryablehttp.DefaultRetryPolicy(ctx, resp, err)
 	}
-	// Adding custom error handler to also return response in case of error
-	retryableClient.ErrorHandler = func(resp *http.Response, err error, numTries int) (*http.Response, error) {
-		return resp, err
-	}
 	httpClient := retryableClient.StandardClient()
 
 	resp, err := sendRequest(httpClient, req)

--- a/client_test.go
+++ b/client_test.go
@@ -790,6 +790,32 @@ func TestGetRunnerScaleSet(t *testing.T) {
 		assert.Equalf(t, actualRetry, expectedRetry, "A retry was expected after the first request but got: %v", actualRetry)
 	})
 
+	t.Run("Rate limit error survives exhausted retries", func(t *testing.T) {
+		attempts := 0
+		server := newActionsServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			attempts++
+			w.Header().Set(headerRetryAfter, "17")
+			w.WriteHeader(http.StatusTooManyRequests)
+		}))
+
+		client, err := newClient(
+			testSystemInfo,
+			server.configURLForOrg("my-org"),
+			auth,
+			WithRetryMax(0),
+		)
+		require.NoError(t, err)
+
+		_, err = client.GetRunnerScaleSet(ctx, 1, scaleSetName)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, RateLimitedError)
+		assert.Equal(t, 1, attempts)
+
+		var rateLimitErr *RateLimitError
+		require.ErrorAs(t, err, &rateLimitErr)
+		assert.Equal(t, 17*time.Second, rateLimitErr.RetryAfter)
+	})
+
 	t.Run("RunnerScaleSet count is zero", func(t *testing.T) {
 		want := (*RunnerScaleSet)(nil)
 		runnerScaleSetsResp := []byte(`{"count":0,"value":[{"id":1,"name":"ScaleSet"}]}`)

--- a/common_client.go
+++ b/common_client.go
@@ -120,6 +120,10 @@ func (o *httpClientOption) newRetryableHTTPClient() (*retryablehttp.Client, erro
 	if retryClient.HTTPClient.Timeout == 0 {
 		retryClient.HTTPClient.Timeout = o.timeout
 	}
+	// Keep the final retryable response so callers can classify its status.
+	if retryClient.ErrorHandler == nil {
+		retryClient.ErrorHandler = retryablehttp.PassthroughErrorHandler
+	}
 
 	retryClient.Logger = o.logger
 

--- a/errors.go
+++ b/errors.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
+	"time"
 )
 
 type scalesetError string
@@ -25,7 +27,85 @@ var (
 	NotFoundError     = scalesetError("not found")
 	UnauthorizedError = scalesetError("unauthorized")
 	ConflictError     = scalesetError("conflict")
+	// RateLimitedError identifies a response rejected because of rate limiting.
+	RateLimitedError = scalesetError("rate limited")
 )
+
+const (
+	headerRetryAfter         = "Retry-After"
+	headerRateLimitRemaining = "X-RateLimit-Remaining"
+	headerRateLimitReset     = "X-RateLimit-Reset"
+	maxRetryAfterSeconds     = (1<<63 - 1) / int64(time.Second)
+)
+
+// RateLimitError carries the server's requested delay. Match the condition
+// with errors.Is(err, RateLimitedError), and read the hint with errors.As.
+type RateLimitError struct {
+	// RetryAfter is zero when the response did not provide a usable delay.
+	RetryAfter time.Duration
+}
+
+func (e *RateLimitError) Error() string {
+	if e.RetryAfter > 0 {
+		return fmt.Sprintf("rate limited (retry after %s)", e.RetryAfter)
+	}
+	return "rate limited"
+}
+
+func (e *RateLimitError) Unwrap() error { return RateLimitedError }
+
+func retryAfterHint(header http.Header, now time.Time) time.Duration {
+	if retryAfter, ok := parseRetryAfter(header.Get(headerRetryAfter), now); ok {
+		return retryAfter
+	}
+	if header.Get(headerRateLimitRemaining) != "0" {
+		return 0
+	}
+
+	reset, err := strconv.ParseInt(header.Get(headerRateLimitReset), 10, 64)
+	if err != nil {
+		return 0
+	}
+
+	retryAfter := time.Unix(reset, 0).Sub(now)
+	if retryAfter < 0 {
+		return 0
+	}
+	return retryAfter
+}
+
+// parseRetryAfter accepts the two Retry-After forms defined by RFC 9110.
+func parseRetryAfter(value string, now time.Time) (time.Duration, bool) {
+	if seconds, err := strconv.ParseUint(value, 10, 64); err == nil {
+		if seconds > uint64(maxRetryAfterSeconds) {
+			return 0, false
+		}
+		return time.Duration(seconds) * time.Second, true
+	}
+
+	retryAt, err := http.ParseTime(value)
+	if err != nil {
+		return 0, false
+	}
+
+	retryAfter := retryAt.Sub(now)
+	if retryAfter < 0 {
+		retryAfter = 0
+	}
+	return retryAfter, true
+}
+
+func isRateLimitResponse(resp *http.Response) bool {
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return true
+	}
+	if resp.StatusCode != http.StatusForbidden {
+		return false
+	}
+
+	return resp.Header.Get(headerRetryAfter) != "" ||
+		resp.Header.Get(headerRateLimitRemaining) == "0"
+}
 
 type actionsExceptionError struct {
 	ExceptionName string `json:"typeName,omitempty"`
@@ -103,6 +183,10 @@ func newRequestResponseError(req *http.Request, resp *http.Response, err error) 
 }
 
 func wrapResponseErrorType(resp *http.Response, err error) error {
+	if isRateLimitResponse(resp) {
+		return fmt.Errorf("%w: %w", &RateLimitError{RetryAfter: retryAfterHint(resp.Header, time.Now())}, err)
+	}
+
 	switch resp.StatusCode {
 	case http.StatusBadRequest:
 		return fmt.Errorf("%w: %w", BadRequestError, err)

--- a/errors_test.go
+++ b/errors_test.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -213,6 +214,79 @@ func TestNewRequestResponseError(t *testing.T) {
 		assert.Contains(t, err.Error(), "still running")
 	})
 
+	t.Run("rate-limit responses map to a typed error", func(t *testing.T) {
+		tests := []struct {
+			name       string
+			statusCode int
+			retryAfter string
+			remaining  string
+			want       bool
+			wantDelay  time.Duration
+		}{
+			{
+				name:       "429 with retry-after",
+				statusCode: http.StatusTooManyRequests,
+				retryAfter: "17",
+				want:       true,
+				wantDelay:  17 * time.Second,
+			},
+			{
+				name:       "429 without retry-after",
+				statusCode: http.StatusTooManyRequests,
+				want:       true,
+			},
+			{
+				name:       "403 with retry-after",
+				statusCode: http.StatusForbidden,
+				retryAfter: "17",
+				want:       true,
+				wantDelay:  17 * time.Second,
+			},
+			{
+				name:       "403 with exhausted GitHub rate limit",
+				statusCode: http.StatusForbidden,
+				remaining:  "0",
+				want:       true,
+			},
+			{
+				name:       "unrelated 403",
+				statusCode: http.StatusForbidden,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				base := errors.New("base")
+				header := make(http.Header)
+				if tt.retryAfter != "" {
+					header.Set(headerRetryAfter, tt.retryAfter)
+				}
+				if tt.remaining != "" {
+					header.Set(headerRateLimitRemaining, tt.remaining)
+				}
+				resp := &http.Response{
+					Status:        fmt.Sprintf("%d %s", tt.statusCode, http.StatusText(tt.statusCode)),
+					StatusCode:    tt.statusCode,
+					ContentLength: 0,
+					Header:        header,
+				}
+
+				err := newRequestResponseError(req(t), resp, base)
+				require.Error(t, err)
+				assert.ErrorIs(t, err, base)
+				assert.Equal(t, tt.want, errors.Is(err, RateLimitedError))
+
+				var rateLimitErr *RateLimitError
+				if tt.want {
+					require.ErrorAs(t, err, &rateLimitErr)
+					assert.Equal(t, tt.wantDelay, rateLimitErr.RetryAfter)
+				} else {
+					assert.False(t, errors.As(err, &rateLimitErr))
+				}
+			})
+		}
+	})
+
 	t.Run("invalid json returns unmarshal error and includes body", func(t *testing.T) {
 		base := errors.New("base")
 		bad := "not-json"
@@ -253,4 +327,44 @@ func TestNewRequestResponseError(t *testing.T) {
 		assert.Equal(t, "SomeException", ex.ExceptionName)
 		assert.Equal(t, "example error message", ex.Message)
 	})
+}
+
+func TestRetryAfterHint(t *testing.T) {
+	now := time.Date(2026, time.July, 19, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name       string
+		retryAfter string
+		remaining  string
+		reset      string
+		want       time.Duration
+	}{
+		{name: "delay seconds", retryAfter: "17", want: 17 * time.Second},
+		{name: "HTTP date", retryAfter: now.Add(30 * time.Second).Format(http.TimeFormat), want: 30 * time.Second},
+		{name: "GitHub reset fallback", remaining: "0", reset: fmt.Sprint(now.Add(45 * time.Second).Unix()), want: 45 * time.Second},
+		{name: "GitHub reset without exhausted limit", reset: fmt.Sprint(now.Add(45 * time.Second).Unix())},
+		{name: "retry-after takes precedence", retryAfter: "17", remaining: "0", reset: fmt.Sprint(now.Add(45 * time.Second).Unix()), want: 17 * time.Second},
+		{name: "zero takes precedence", retryAfter: "0", remaining: "0", reset: fmt.Sprint(now.Add(45 * time.Second).Unix())},
+		{name: "past HTTP date", retryAfter: now.Add(-time.Second).Format(http.TimeFormat)},
+		{name: "negative seconds", retryAfter: "-1"},
+		{name: "invalid", retryAfter: "later"},
+		{name: "duration overflow", retryAfter: "9223372037"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			header := make(http.Header)
+			if tt.retryAfter != "" {
+				header.Set(headerRetryAfter, tt.retryAfter)
+			}
+			if tt.remaining != "" {
+				header.Set(headerRateLimitRemaining, tt.remaining)
+			}
+			if tt.reset != "" {
+				header.Set(headerRateLimitReset, tt.reset)
+			}
+
+			assert.Equal(t, tt.want, retryAfterHint(header, now))
+		})
+	}
 }


### PR DESCRIPTION
## What

Rate-limited responses currently surface as unwrapped generic errors, so callers cannot distinguish rate limiting from other failures without string-matching status text — and the server's requested delay is lost entirely (the `Retry-After` header is not part of the error message). This wraps them like the existing status sentinels (`BadRequestError`, `UnauthorizedError`, `NotFoundError`, `ConflictError`):

```go
if errors.Is(err, scaleset.RateLimitedError) {
    var rl *scaleset.RateLimitError
    errors.As(err, &rl)
    // rl.RetryAfter is the server's requested delay (zero when none was sent)
}
```

Callers building autoscalers or control planes on this SDK need this signal to back off adaptively, emit throttling metrics, and honor the delay GitHub's API guidelines ask integrators to respect. It follows the sentinel pattern the client already uses for 400/401/404/409 — one more case in the existing switch, plus the delay hint.

## Classification

Covers how GitHub actually signals rate limiting:

- `429` — always.
- `403` with `Retry-After` (secondary rate limits) or with `X-RateLimit-Remaining: 0` (a spent primary limit). Unrelated 403s are untouched.

The delay hint prefers `Retry-After` (both RFC 9110 forms — delay-seconds and HTTP-date — with overflow and negative guards) and falls back to `X-RateLimit-Reset` when the primary limit is spent.

## Bug fix this depends on

`go-retryablehttp` retries 429s internally, and its default `ErrorHandler` discards the final response once retries are exhausted — so the status classification in `newRequestResponseError` was unreachable on exactly the rate-limited path (the caller got a bare `giving up after N attempt(s)` error with no response attached). This PR installs `retryablehttp.PassthroughErrorHandler` centrally in `newRetryableHTTPClient` (only when no custom handler is set), replacing the single hand-rolled copy in `getActionsServiceAdminConnectionRequest`. After exhausted retries the final response now flows through the normal status-code error path, so these errors also gain the request/activity-ID context that path adds.

## Testing

- Table-driven classification tests (429/403 variants, unrelated 403 untouched).
- `retryAfterHint` tests against a fixed clock: both RFC 9110 forms, the `X-RateLimit-Reset` fallback, precedence, past dates, negative/invalid/overflowing values.
- A live-server test through the full retry stack asserting the typed error survives exhausted retries.

We carry this in our fork, where the consumer uses it to distinguish rate-limit push-back from ordinary failures in an adaptive mint-concurrency limiter.

## Note on the base

This branch is stacked on #116 (`fix/testdata-cert-expiry`) so its test suite runs green — `main` currently fails `TestServerWithSelfSignedCertificates` on the expired committed testdata certificates that #116 replaces with runtime-generated ones. The rate-limit change itself is the single top commit; the diff collapses to it once #116 merges.
