### PR TITLE
feat: TokenProvider for externally minted bearer tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,12 +142,41 @@ If you are not a Go developer, you can still:
 
 ## Authentication
 
-Two options:
+Three options:
 
 1. **GitHub App (preferred):** Stronger scoping & rotation. Provide: `ClientID`, `InstallationID`, `PrivateKey`.
-2. **PAT (personal access token):** Simpler but broader scoped.
+2. **GitHub App with custom JWT signing:** For KMS/HSM-backed keys where private key material cannot be in memory. Provide a `JWTProvider` implementation.
+3. **PAT (personal access token):** Simpler but broader scoped.
 
 The client automatically exchanges credentials for a registration token + admin token behind the scenes and refreshes them before expiry.
+
+### Custom JWT Signing (KMS/HSM)
+
+For organizations that require private key material to stay within a KMS or HSM boundary:
+
+```go
+// Using a crypto.Signer (AWS KMS, GCP Cloud KMS, Azure Key Vault, etc.)
+provider := &scaleset.SignerJWTProvider{
+    ClientID: "Iv1.abc123",
+    Signer:   myKMSSigner, // any crypto.Signer with an RSA key
+}
+
+client, err := scaleset.NewClientWithJWTProvider(
+    scaleset.ClientWithJWTProviderConfig{
+        GitHubConfigURL: "https://github.com/my-org",
+        InstallationID:  12345,
+    },
+    provider,
+)
+```
+
+Or wrap any function that returns a signed JWT:
+
+```go
+provider := scaleset.JWTProviderFunc(func(ctx context.Context) (string, error) {
+    return getJWTFromExternalService(ctx)
+})
+```
 
 You can find more details on required permissions in the [GitHub Docs](https://docs.github.com/en/actions/tutorials/use-actions-runner-controller/authenticate-to-the-api).
 
@@ -175,6 +204,7 @@ Assigning more than one label to a scale set is supported on **GHES 3.18 and lat
 ## Security Notes
 
 - Always prefer GitHub App credentials; rotate PATs if you must use them.
+- Use `SignerJWTProvider` or `JWTProviderFunc` to keep private key material in a KMS/HSM.
 - Treat JIT configs as secrets until consumed.
 
 ---

--- a/client.go
+++ b/client.go
@@ -106,26 +106,43 @@ func (a *GitHubAppAuth) Validate() error {
 type actionsAuth struct {
 	// token is a GitHub PAT (mutually exclusive with jwtProvider).
 	token string
+	// tokenProvider supplies bearer tokens minted (or cached) outside the
+	// client, consulted on every re-authentication (mutually exclusive with
+	// token and jwtProvider).
+	tokenProvider TokenProvider
 	// jwtProvider creates JWTs for GitHub App auth.
 	jwtProvider JWTProvider
 	// installationID is the GitHub App installation ID (used with jwtProvider).
 	installationID int64
 }
 
-// validate does the basic validation check, ensuring that
-// either GitHub App credentials (a JWT provider with an installation ID)
-// or a personal access token is provided.
+// validate does the basic validation check, ensuring that exactly one
+// credential source is provided: a personal access token, a token provider,
+// or GitHub App credentials (a JWT provider with an installation ID).
 //
 // This method does not validate the credentials against GitHub, so it does not
 // check if the credentials are correct or have the necessary permissions.
 func (a actionsAuth) validate() error {
-	if a.token == "" && a.jwtProvider == nil {
+	sources := 0
+	if a.token != "" {
+		sources++
+	}
+	if a.tokenProvider != nil {
+		sources++
+	}
+	if a.jwtProvider != nil {
+		sources++
+	}
+	switch {
+	case sources == 0:
 		return fmt.Errorf("either GitHub App credentials or personal access token is required")
-	}
-	if a.token != "" && a.jwtProvider != nil {
+	// The pre-existing App-plus-PAT conflict keeps its original wording, so
+	// callers matching on that message are unaffected by the added source.
+	case a.token != "" && a.jwtProvider != nil && a.tokenProvider == nil:
 		return fmt.Errorf("cannot provide both GitHub App credentials and personal access token")
-	}
-	if a.jwtProvider != nil && a.installationID == 0 {
+	case sources > 1:
+		return fmt.Errorf("cannot provide more than one of: GitHub App credentials, personal access token, token provider")
+	case a.jwtProvider != nil && a.installationID == 0:
 		return fmt.Errorf("app installation ID is required")
 	}
 	return nil
@@ -199,6 +216,32 @@ func NewClientWithPersonalAccessToken(config NewClientWithPersonalAccessTokenCon
 		config.GitHubConfigURL,
 		actionsAuth{
 			token: config.PersonalAccessToken,
+		},
+		options...,
+	)
+}
+
+// ClientWithTokenProviderConfig contains the configuration for creating a new Client
+// using a TokenProvider for GitHub API authentication.
+type ClientWithTokenProviderConfig struct {
+	GitHubConfigURL string
+	SystemInfo      SystemInfo
+}
+
+// NewClientWithTokenProvider creates a new Client that authenticates its GitHub
+// API calls with bearer tokens from the provider. The provider is consulted on
+// every re-authentication, so short-lived credentials — such as GitHub App
+// installation tokens minted (or cached) outside the client — stay valid for
+// the client's whole lifetime.
+func NewClientWithTokenProvider(config ClientWithTokenProviderConfig, provider TokenProvider, options ...HTTPOption) (*Client, error) {
+	if provider == nil {
+		return nil, fmt.Errorf("token provider is required")
+	}
+	return newClient(
+		config.SystemInfo,
+		config.GitHubConfigURL,
+		actionsAuth{
+			tokenProvider: provider,
 		},
 		options...,
 	)
@@ -856,9 +899,17 @@ func (c *Client) getRunnerRegistrationToken(ctx context.Context) (*registrationT
 
 	bearerToken := ""
 
-	if c.creds.token != "" {
+	switch {
+	case c.creds.tokenProvider != nil:
+		token, err := c.creds.tokenProvider.Token(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get token from token provider: %w", err)
+		}
+
+		bearerToken = fmt.Sprintf("Bearer %v", token)
+	case c.creds.token != "":
 		bearerToken = fmt.Sprintf("Bearer %v", c.creds.token)
-	} else {
+	default:
 		accessToken, err := c.fetchAccessToken(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch access token: %w", err)

--- a/client.go
+++ b/client.go
@@ -104,27 +104,29 @@ func (a *GitHubAppAuth) Validate() error {
 }
 
 type actionsAuth struct {
-	// app is the GitHub app credentials
-	app *GitHubAppAuth
-	// GitHub PAT
+	// token is a GitHub PAT (mutually exclusive with jwtProvider).
 	token string
+	// jwtProvider creates JWTs for GitHub App auth.
+	jwtProvider JWTProvider
+	// installationID is the GitHub App installation ID (used with jwtProvider).
+	installationID int64
 }
 
 // validate does the basic validation check, ensuring that
-// either GitHub App credentials or a personal access token is provided.
-// If GitHub App credentials are provided, it further validates the credentials.
+// either GitHub App credentials (a JWT provider with an installation ID)
+// or a personal access token is provided.
 //
 // This method does not validate the credentials against GitHub, so it does not
 // check if the credentials are correct or have the necessary permissions.
 func (a actionsAuth) validate() error {
-	if a.token == "" && a.app == nil {
+	if a.token == "" && a.jwtProvider == nil {
 		return fmt.Errorf("either GitHub App credentials or personal access token is required")
 	}
-	if a.token != "" && a.app != nil {
+	if a.token != "" && a.jwtProvider != nil {
 		return fmt.Errorf("cannot provide both GitHub App credentials and personal access token")
 	}
-	if a.app != nil {
-		return a.app.Validate()
+	if a.jwtProvider != nil && a.installationID == 0 {
+		return fmt.Errorf("app installation ID is required")
 	}
 	return nil
 }
@@ -163,11 +165,21 @@ type ClientWithGitHubAppConfig struct {
 
 // NewClientWithGitHubApp creates a new Client using GitHub App credentials.
 func NewClientWithGitHubApp(config ClientWithGitHubAppConfig, options ...HTTPOption) (*Client, error) {
+	if err := config.GitHubAppAuth.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid credentials: %w", err)
+	}
+
+	provider, err := newPEMJWTProvider(config.GitHubAppAuth.ClientID, config.GitHubAppAuth.PrivateKey)
+	if err != nil {
+		return nil, fmt.Errorf("invalid credentials: %w", err)
+	}
+
 	return newClient(
 		config.SystemInfo,
 		config.GitHubConfigURL,
 		actionsAuth{
-			app: &config.GitHubAppAuth,
+			jwtProvider:    provider,
+			installationID: config.GitHubAppAuth.InstallationID,
 		},
 		options...,
 	)
@@ -187,6 +199,35 @@ func NewClientWithPersonalAccessToken(config NewClientWithPersonalAccessTokenCon
 		config.GitHubConfigURL,
 		actionsAuth{
 			token: config.PersonalAccessToken,
+		},
+		options...,
+	)
+}
+
+// ClientWithJWTProviderConfig contains the configuration for creating a new Client
+// using a custom JWTProvider for GitHub App authentication.
+type ClientWithJWTProviderConfig struct {
+	GitHubConfigURL string
+	InstallationID  int64
+	SystemInfo      SystemInfo
+}
+
+// NewClientWithJWTProvider creates a new Client using a custom JWTProvider for GitHub App
+// authentication. This enables KMS-backed signing where private key material never
+// leaves the secure boundary.
+func NewClientWithJWTProvider(config ClientWithJWTProviderConfig, provider JWTProvider, options ...HTTPOption) (*Client, error) {
+	if provider == nil {
+		return nil, fmt.Errorf("JWT provider is required")
+	}
+	if config.InstallationID == 0 {
+		return nil, fmt.Errorf("installation ID is required")
+	}
+	return newClient(
+		config.SystemInfo,
+		config.GitHubConfigURL,
+		actionsAuth{
+			jwtProvider:    provider,
+			installationID: config.InstallationID,
 		},
 		options...,
 	)
@@ -818,7 +859,7 @@ func (c *Client) getRunnerRegistrationToken(ctx context.Context) (*registrationT
 	if c.creds.token != "" {
 		bearerToken = fmt.Sprintf("Bearer %v", c.creds.token)
 	} else {
-		accessToken, err := c.fetchAccessToken(ctx, c.creds.app)
+		accessToken, err := c.fetchAccessToken(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch access token: %w", err)
 		}
@@ -855,13 +896,13 @@ type accessToken struct {
 	ExpiresAt time.Time `json:"expires_at"`
 }
 
-func (c *Client) fetchAccessToken(ctx context.Context, creds *GitHubAppAuth) (*accessToken, error) {
-	accessTokenJWT, err := createJWTForGitHubApp(creds)
+func (c *Client) fetchAccessToken(ctx context.Context) (*accessToken, error) {
+	accessTokenJWT, err := c.creds.jwtProvider.Token(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create JWT for GitHub app: %w", err)
+		return nil, fmt.Errorf("failed to get JWT for GitHub App auth: %w", err)
 	}
 
-	path := fmt.Sprintf("/app/installations/%v/access_tokens", creds.InstallationID)
+	path := fmt.Sprintf("/app/installations/%v/access_tokens", c.creds.installationID)
 	req, err := c.newGitHubAPIRequest(ctx, http.MethodPost, path, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create new GitHub API request: %w", err)
@@ -993,30 +1034,6 @@ func createRegistrationTokenPath(config *gitHubConfig) (string, error) {
 	default:
 		return "", fmt.Errorf("unknown scope for config url: %s", config.configURL)
 	}
-}
-
-func createJWTForGitHubApp(appAuth *GitHubAppAuth) (string, error) {
-	// Encode as JWT
-	// See https://docs.github.com/en/developers/apps/building-github-apps/authenticating-with-github-apps#authenticating-as-a-github-app
-
-	// Going back in time a bit helps with clock skew.
-	issuedAt := time.Now().Add(-60 * time.Second)
-	// Max expiration date is 10 minutes.
-	expiresAt := issuedAt.Add(9 * time.Minute)
-	claims := &jwt.RegisteredClaims{
-		IssuedAt:  jwt.NewNumericDate(issuedAt),
-		ExpiresAt: jwt.NewNumericDate(expiresAt),
-		Issuer:    appAuth.ClientID,
-	}
-
-	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
-
-	privateKey, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(appAuth.PrivateKey))
-	if err != nil {
-		return "", fmt.Errorf("failed to parse RSA private key from PEM: %w", err)
-	}
-
-	return token.SignedString(privateKey)
 }
 
 // Returns slice of body without utf-8 byte order mark.

--- a/client.go
+++ b/client.go
@@ -16,7 +16,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/hashicorp/go-retryablehttp"
 )
 

--- a/client_test.go
+++ b/client_test.go
@@ -19,7 +19,7 @@ import (
 	"time"
 
 	"github.com/actions/scaleset/internal/testserver"
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/client_test.go
+++ b/client_test.go
@@ -120,7 +120,7 @@ func TestNewClientWithPersonalAccessToken(t *testing.T) {
 		require.NotNil(t, client)
 
 		assert.Equal(t, "ghp_test_token", client.creds.token)
-		assert.Nil(t, client.creds.app)
+		assert.Nil(t, client.creds.jwtProvider)
 		assert.Equal(t, "my-org", client.config.organization)
 		assert.Equal(t, "my-repo", client.config.repository)
 		assert.Equal(t, testSystemInfo, client.SystemInfo())
@@ -156,10 +156,8 @@ func TestNewClientWithGitHubApp(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, client)
 
-		require.NotNil(t, client.creds.app)
-		assert.Equal(t, "12345", client.creds.app.ClientID)
-		assert.EqualValues(t, 67890, client.creds.app.InstallationID)
-		assert.Equal(t, samplePrivateKey, client.creds.app.PrivateKey)
+		require.NotNil(t, client.creds.jwtProvider)
+		assert.EqualValues(t, 67890, client.creds.installationID)
 		assert.Equal(t, "", client.creds.token)
 		assert.Equal(t, "my-org", client.config.organization)
 		assert.Equal(t, "my-repo", client.config.repository)
@@ -218,6 +216,22 @@ func TestNewClientWithGitHubApp(t *testing.T) {
 			assert.Contains(t, err.Error(), "app private key is required")
 		})
 	})
+
+	t.Run("returns error for an invalid private key", func(t *testing.T) {
+		client, err := NewClientWithGitHubApp(ClientWithGitHubAppConfig{
+			GitHubConfigURL: "https://github.com/my-org/my-repo",
+			GitHubAppAuth: GitHubAppAuth{
+				ClientID:       "12345",
+				InstallationID: 67890,
+				PrivateKey:     "not a private key",
+			},
+			SystemInfo: testSystemInfo,
+		})
+		require.Error(t, err)
+		assert.Nil(t, client)
+		assert.Contains(t, err.Error(), "invalid credentials")
+		assert.Contains(t, err.Error(), "failed to parse RSA private key from PEM")
+	})
 }
 
 func TestNewClientWithBothTokenAndGitHubApp(t *testing.T) {
@@ -226,12 +240,9 @@ func TestNewClientWithBothTokenAndGitHubApp(t *testing.T) {
 			testSystemInfo,
 			"https://github.com/my-org/my-repo",
 			actionsAuth{
-				token: "ghp_test_token",
-				app: &GitHubAppAuth{
-					ClientID:       "12345",
-					InstallationID: 67890,
-					PrivateKey:     samplePrivateKey,
-				},
+				token:          "ghp_test_token",
+				jwtProvider:    JWTProviderFunc(func(context.Context) (string, error) { return "jwt", nil }),
+				installationID: 67890,
 			},
 		)
 
@@ -1551,6 +1562,93 @@ func startNewTLSTestServer(t *testing.T, certPath, keyPath string, handler http.
 	server.StartTLS()
 
 	return server
+}
+
+func TestNewClientWithJWTProvider(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("full flow with custom JWT provider", func(t *testing.T) {
+		var capturedAuthHeader string
+		server := testserver.New(t, nil,
+			testserver.WithInstallationAccessTokenHandler(func(w http.ResponseWriter, r *http.Request) {
+				capturedAuthHeader = r.Header.Get("Authorization")
+				w.WriteHeader(http.StatusCreated)
+				w.Write([]byte(`{"token":"ghs_test_installation_token","expires_at":"2099-01-01T00:00:00Z"}`))
+			}),
+		)
+
+		provider := JWTProviderFunc(func(_ context.Context) (string, error) {
+			return "my-custom-jwt", nil
+		})
+
+		client, err := NewClientWithJWTProvider(
+			ClientWithJWTProviderConfig{
+				GitHubConfigURL: server.ConfigURLForOrg("my-org"),
+				InstallationID:  42,
+				SystemInfo:      testSystemInfo,
+			},
+			provider,
+		)
+		require.NoError(t, err)
+
+		// Trigger the full auth flow by making a request that needs authentication
+		req, err := client.newActionsServiceRequest(ctx, http.MethodGet, "/test", nil)
+		require.NoError(t, err)
+		assert.NotNil(t, req)
+
+		// Verify our custom JWT was used in the installation access token request
+		assert.Equal(t, "Bearer my-custom-jwt", capturedAuthHeader)
+	})
+
+	t.Run("provider error propagates", func(t *testing.T) {
+		server := testserver.New(t, nil)
+
+		expectedErr := errors.New("kms unavailable")
+		provider := JWTProviderFunc(func(_ context.Context) (string, error) {
+			return "", expectedErr
+		})
+
+		client, err := NewClientWithJWTProvider(
+			ClientWithJWTProviderConfig{
+				GitHubConfigURL: server.ConfigURLForOrg("my-org"),
+				InstallationID:  42,
+				SystemInfo:      testSystemInfo,
+			},
+			provider,
+		)
+		require.NoError(t, err)
+
+		_, err = client.newActionsServiceRequest(ctx, http.MethodGet, "/test", nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "kms unavailable")
+	})
+
+	t.Run("nil provider returns error", func(t *testing.T) {
+		_, err := NewClientWithJWTProvider(
+			ClientWithJWTProviderConfig{
+				GitHubConfigURL: "https://github.com/my-org",
+				InstallationID:  42,
+			},
+			nil,
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "JWT provider is required")
+	})
+
+	t.Run("zero installation ID returns error", func(t *testing.T) {
+		provider := JWTProviderFunc(func(_ context.Context) (string, error) {
+			return "jwt", nil
+		})
+		_, err := NewClientWithJWTProvider(
+			ClientWithJWTProviderConfig{
+				GitHubConfigURL: "https://github.com/my-org",
+				InstallationID:  0,
+			},
+			provider,
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "installation ID is required")
+	})
 }
 
 const samplePrivateKey = `-----BEGIN PRIVATE KEY-----

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.3
 
 require (
 	github.com/docker/docker v28.5.2+incompatible
-	github.com/golang-jwt/jwt/v4 v4.5.2
+	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/go-github/v79 v79.0.0
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-retryablehttp v0.7.8

--- a/go.sum
+++ b/go.sum
@@ -252,8 +252,8 @@ github.com/godoc-lint/godoc-lint v0.11.2/go.mod h1:iVpGdL1JCikNH2gGeAn3Hh+AgN5Gx
 github.com/gofrs/flock v0.13.0 h1:95JolYOvGMqeH31+FC7D2+uULf6mG61mEZ/A8dRYMzw=
 github.com/gofrs/flock v0.13.0/go.mod h1:jxeyy9R1auM5S6JYDBhDt+E2TCo7DkratH4Pgi8P+Z0=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
-github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=
-github.com/golang-jwt/jwt/v4 v4.5.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/internal/testserver/server.go
+++ b/internal/testserver/server.go
@@ -39,6 +39,12 @@ func NewUnstarted(t testing.TB, handler http.Handler, options ...actionsServerOp
 	}
 
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// handle fetchAccessToken (GitHub App installation access token)
+		if strings.HasSuffix(r.URL.Path, "/access_tokens") && strings.Contains(r.URL.Path, "/app/installations/") {
+			server.installationAccessTokenHandler(w, r)
+			return
+		}
+
 		// handle getRunnerRegistrationToken
 		if strings.HasSuffix(r.URL.Path, "/runners/registration-token") {
 			server.runnerRegistrationTokenHandler(w, r)
@@ -79,15 +85,29 @@ func WithActionsRegistrationTokenHandler(h http.HandlerFunc) actionsServerOption
 	}
 }
 
+func WithInstallationAccessTokenHandler(h http.HandlerFunc) actionsServerOption {
+	return func(s *actionsServer) {
+		s.installationAccessTokenHandler = h
+	}
+}
+
 type actionsServer struct {
 	*httptest.Server
 
 	token                          string
 	runnerRegistrationTokenHandler http.HandlerFunc
 	actionRegistrationTokenHandler http.HandlerFunc
+	installationAccessTokenHandler http.HandlerFunc
 }
 
 func (s *actionsServer) setDefaults(t testing.TB) {
+	if s.installationAccessTokenHandler == nil {
+		s.installationAccessTokenHandler = func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusCreated)
+			w.Write([]byte(`{"token":"ghs_installation_token","expires_at":"2099-01-01T00:00:00Z"}`))
+		}
+	}
+
 	if s.runnerRegistrationTokenHandler == nil {
 		s.runnerRegistrationTokenHandler = func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusCreated)

--- a/internal/testserver/server.go
+++ b/internal/testserver/server.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/require"
 )
 

--- a/jwt_provider.go
+++ b/jwt_provider.go
@@ -1,0 +1,120 @@
+package scaleset
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"fmt"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// JWTProvider creates short-lived JWTs for GitHub App authentication.
+// Implementations must be safe for concurrent use.
+//
+// The returned JWT must be RS256-signed with iss (Client ID), iat, and exp claims.
+// See https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-json-web-token-jwt-for-a-github-app
+type JWTProvider interface {
+	Token(ctx context.Context) (string, error)
+}
+
+// SignerJWTProvider creates GitHub App JWTs using a [crypto.Signer].
+// This enables KMS-backed keys (AWS KMS, GCP Cloud KMS, Azure Key Vault)
+// where private key material never leaves the secure boundary.
+// The Signer's Public() method must return *[crypto/rsa.PublicKey].
+type SignerJWTProvider struct {
+	ClientID string
+	Signer   crypto.Signer
+}
+
+// Token creates a signed JWT for GitHub App authentication.
+//
+// It uses the JWT library to assemble the token, then signs the resulting
+// digest through the crypto.Signer because SignedString requires a concrete
+// *rsa.PrivateKey.
+func (p *SignerJWTProvider) Token(ctx context.Context) (string, error) {
+	if p == nil || p.Signer == nil {
+		return "", fmt.Errorf("signer is required")
+	}
+	if p.ClientID == "" {
+		return "", fmt.Errorf("client ID is required")
+	}
+	if err := ctx.Err(); err != nil {
+		return "", fmt.Errorf("sign app JWT: %w", err)
+	}
+
+	publicKey := p.Signer.Public()
+	if _, ok := publicKey.(*rsa.PublicKey); !ok {
+		return "", fmt.Errorf("signer public key must be *rsa.PublicKey, got %T", publicKey)
+	}
+
+	token := newGitHubAppJWT(p.ClientID)
+	signingInput, err := token.SigningString()
+	if err != nil {
+		return "", fmt.Errorf("create app JWT signing input: %w", err)
+	}
+
+	digest := sha256.Sum256([]byte(signingInput))
+	sig, err := p.Signer.Sign(rand.Reader, digest[:], crypto.SHA256)
+	if err != nil {
+		return "", fmt.Errorf("sign app JWT: %w", err)
+	}
+	return signingInput + "." + token.EncodeSegment(sig), nil
+}
+
+// pemJWTProvider signs JWTs using a PEM-encoded RSA private key.
+type pemJWTProvider struct {
+	clientID   string
+	privateKey *rsa.PrivateKey
+}
+
+// newPEMJWTProvider creates a JWTProvider from a PEM-encoded RSA private key string.
+func newPEMJWTProvider(clientID, pemKey string) (*pemJWTProvider, error) {
+	privateKey, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(pemKey))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse RSA private key from PEM: %w", err)
+	}
+	return &pemJWTProvider{
+		clientID:   clientID,
+		privateKey: privateKey,
+	}, nil
+}
+
+func (p *pemJWTProvider) Token(ctx context.Context) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", fmt.Errorf("sign app JWT: %w", err)
+	}
+	return newGitHubAppJWT(p.clientID).SignedString(p.privateKey)
+}
+
+func newGitHubAppJWT(clientID string) *jwt.Token {
+	issuedAt := time.Now().Add(-time.Minute)
+	expiresAt := issuedAt.Add(9 * time.Minute)
+
+	return jwt.NewWithClaims(jwt.SigningMethodRS256, &jwt.RegisteredClaims{
+		IssuedAt:  jwt.NewNumericDate(issuedAt),
+		ExpiresAt: jwt.NewNumericDate(expiresAt),
+		Issuer:    clientID,
+	})
+}
+
+// Ensure both providers satisfy the interface at compile time.
+var (
+	_ JWTProvider = (*SignerJWTProvider)(nil)
+	_ JWTProvider = (*pemJWTProvider)(nil)
+	_ JWTProvider = JWTProviderFunc(nil)
+)
+
+// JWTProviderFunc adapts a function to a [JWTProvider].
+type JWTProviderFunc func(ctx context.Context) (string, error)
+
+// Token calls f with ctx.
+func (f JWTProviderFunc) Token(ctx context.Context) (string, error) {
+	if f == nil {
+		return "", fmt.Errorf("JWT provider function is required")
+	}
+	return f(ctx)
+}

--- a/jwt_provider_test.go
+++ b/jwt_provider_test.go
@@ -1,0 +1,169 @@
+package scaleset
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func generateTestKey(t *testing.T) *rsa.PrivateKey {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	return key
+}
+
+func pemEncodeKey(key *rsa.PrivateKey) string {
+	return string(pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	}))
+}
+
+func parseTestJWT(t *testing.T, provider JWTProvider, key *rsa.PublicKey) *jwt.RegisteredClaims {
+	t.Helper()
+	claims := &jwt.RegisteredClaims{}
+
+	tokenString, err := provider.Token(context.Background())
+	require.NoError(t, err)
+
+	token, err := jwt.ParseWithClaims(
+		tokenString,
+		claims,
+		func(_ *jwt.Token) (any, error) { return key, nil },
+		jwt.WithValidMethods([]string{jwt.SigningMethodRS256.Alg()}),
+	)
+	require.NoError(t, err)
+	require.True(t, token.Valid)
+
+	return claims
+}
+
+func TestJWTProviders(t *testing.T) {
+	const clientID = "Iv1.test123"
+	key := generateTestKey(t)
+	pemProvider, err := newPEMJWTProvider(clientID, pemEncodeKey(key))
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		provider JWTProvider
+	}{
+		{name: "PEM private key", provider: pemProvider},
+		{name: "crypto signer", provider: &SignerJWTProvider{ClientID: clientID, Signer: key}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			claims := parseTestJWT(t, tt.provider, &key.PublicKey)
+
+			assert.Equal(t, clientID, claims.Issuer)
+			require.NotNil(t, claims.IssuedAt)
+			require.NotNil(t, claims.ExpiresAt)
+			assert.WithinDuration(t, time.Now().Add(-time.Minute), claims.IssuedAt.Time, 2*time.Second)
+			assert.Equal(t, 9*time.Minute, claims.ExpiresAt.Sub(claims.IssuedAt.Time))
+
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			_, err := tt.provider.Token(ctx)
+			require.ErrorIs(t, err, context.Canceled)
+		})
+	}
+}
+
+func TestPEMJWTProviderInvalidPEM(t *testing.T) {
+	_, err := newPEMJWTProvider("test", "not-a-valid-pem")
+	require.Error(t, err)
+}
+
+type testSigner struct {
+	publicKey crypto.PublicKey
+	err       error
+}
+
+func (s *testSigner) Public() crypto.PublicKey {
+	return s.publicKey
+}
+
+func (s *testSigner) Sign(_ io.Reader, _ []byte, _ crypto.SignerOpts) ([]byte, error) {
+	return nil, s.err
+}
+
+func TestSignerJWTProviderValidation(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider *SignerJWTProvider
+		wantErr  string
+	}{
+		{name: "nil provider", wantErr: "signer is required"},
+		{name: "missing signer", provider: &SignerJWTProvider{ClientID: "test"}, wantErr: "signer is required"},
+		{
+			name:     "missing client ID",
+			provider: &SignerJWTProvider{Signer: &testSigner{publicKey: &rsa.PublicKey{}}},
+			wantErr:  "client ID is required",
+		},
+		{
+			name:     "non-RSA signer",
+			provider: &SignerJWTProvider{ClientID: "test", Signer: &testSigner{publicKey: "not an RSA key"}},
+			wantErr:  "signer public key must be *rsa.PublicKey",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.provider.Token(context.Background())
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestSignerJWTProviderSigningError(t *testing.T) {
+	expectedErr := errors.New("KMS unavailable")
+	provider := &SignerJWTProvider{
+		ClientID: "test",
+		Signer: &testSigner{
+			publicKey: &rsa.PublicKey{},
+			err:       expectedErr,
+		},
+	}
+
+	_, err := provider.Token(context.Background())
+	require.ErrorIs(t, err, expectedErr)
+}
+
+func TestJWTProviderFunc(t *testing.T) {
+	t.Run("returns the function result", func(t *testing.T) {
+		provider := JWTProviderFunc(func(_ context.Context) (string, error) {
+			return "test-jwt-token", nil
+		})
+
+		token, err := provider.Token(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, "test-jwt-token", token)
+	})
+
+	t.Run("propagates errors", func(t *testing.T) {
+		expectedErr := errors.New("KMS unavailable")
+		provider := JWTProviderFunc(func(_ context.Context) (string, error) {
+			return "", expectedErr
+		})
+
+		_, err := provider.Token(context.Background())
+		require.ErrorIs(t, err, expectedErr)
+	})
+
+	t.Run("rejects a nil function", func(t *testing.T) {
+		var provider JWTProviderFunc
+		_, err := provider.Token(context.Background())
+		require.Error(t, err)
+	})
+}

--- a/token_provider.go
+++ b/token_provider.go
@@ -1,0 +1,50 @@
+package scaleset
+
+import "context"
+
+// TokenProvider supplies bearer tokens for GitHub API authentication.
+// Implementations must be safe for concurrent use.
+//
+// The client consults the provider each time it (re-)authenticates against
+// the GitHub API, so implementations can rotate short-lived credentials —
+// for example GitHub App installation access tokens minted (or cached)
+// outside the client — without the client being rebuilt.
+//
+// The token must be accepted at the scope of the client's config URL, and
+// not every credential is valid at every scope:
+//
+//   - Enterprise (https://HOST/enterprises/NAME) requires a personal access
+//     token with the manage_runners:enterprise scope. Today a GitHub App is
+//     installed on an organization or a repository, never on an enterprise,
+//     so no installation access token can be minted at this scope. Nothing
+//     in the client enforces that: if GitHub ships enterprise-installable
+//     Apps, their installation tokens flow through this seam unchanged.
+//   - Organization (https://HOST/ORG) accepts a personal access token with
+//     admin:org, or an installation access token from an App holding the
+//     organization_self_hosted_runners permission.
+//   - Repository (https://HOST/ORG/REPO) accepts a personal access token
+//     with repo, or an installation access token from an App holding the
+//     administration permission.
+//
+// Whatever is returned is sent verbatim as an Authorization: Bearer header
+// for a single request; the client neither inspects nor caches it. A
+// provider handing out expiring credentials therefore owns their renewal —
+// which is the point of the seam, since renewal can then be shared across
+// clients and processes rather than duplicated inside each one.
+type TokenProvider interface {
+	Token(ctx context.Context) (string, error)
+}
+
+// tokenFuncProvider wraps a plain function as a TokenProvider.
+type tokenFuncProvider struct {
+	fn func(ctx context.Context) (string, error)
+}
+
+func (p *tokenFuncProvider) Token(ctx context.Context) (string, error) {
+	return p.fn(ctx)
+}
+
+// TokenProviderFunc wraps a function as a TokenProvider.
+func TokenProviderFunc(fn func(ctx context.Context) (string, error)) TokenProvider {
+	return &tokenFuncProvider{fn: fn}
+}

--- a/token_provider_test.go
+++ b/token_provider_test.go
@@ -1,0 +1,119 @@
+package scaleset
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTokenProviderFunc(t *testing.T) {
+	provider := TokenProviderFunc(func(context.Context) (string, error) {
+		return "ghs_test", nil
+	})
+	token, err := provider.Token(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "ghs_test", token)
+}
+
+func TestNewClientWithTokenProvider(t *testing.T) {
+	t.Run("requires a provider", func(t *testing.T) {
+		_, err := NewClientWithTokenProvider(ClientWithTokenProviderConfig{
+			GitHubConfigURL: "https://github.com/my-org",
+		}, nil)
+		assert.NotNil(t, err)
+	})
+
+	t.Run("consults the provider on every re-authentication", func(t *testing.T) {
+		ctx := context.Background()
+
+		var mu sync.Mutex
+		var bearers []string
+		var calls atomic.Int64
+
+		server := newActionsServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Write([]byte(`{"count":1,"encodedJITConfig":"config"}`))
+		}), withShortLivedAdminToken(t))
+		server.Config.Handler = wrapRegistrationTokenCapture(server.Config.Handler, &mu, &bearers)
+
+		provider := TokenProviderFunc(func(context.Context) (string, error) {
+			return fmt.Sprintf("ghs_%d", calls.Add(1)), nil
+		})
+
+		client, err := NewClientWithTokenProvider(ClientWithTokenProviderConfig{
+			GitHubConfigURL: server.configURLForOrg("my-org"),
+		}, provider)
+		require.NoError(t, err)
+
+		// The admin token is already inside the refresh window, so each call
+		// re-authenticates — and must pick up a fresh token from the provider.
+		_, err = client.GenerateJitRunnerConfig(ctx, &RunnerScaleSetJitRunnerSetting{}, 1)
+		require.NoError(t, err)
+		_, err = client.GenerateJitRunnerConfig(ctx, &RunnerScaleSetJitRunnerSetting{}, 1)
+		require.NoError(t, err)
+
+		mu.Lock()
+		defer mu.Unlock()
+		assert.Equal(t, []string{"Bearer ghs_1", "Bearer ghs_2"}, bearers)
+	})
+
+	t.Run("provider errors fail the request", func(t *testing.T) {
+		ctx := context.Background()
+
+		server := newActionsServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Write([]byte(`{}`))
+		}))
+
+		provider := TokenProviderFunc(func(context.Context) (string, error) {
+			return "", errors.New("token store unavailable")
+		})
+
+		client, err := NewClientWithTokenProvider(ClientWithTokenProviderConfig{
+			GitHubConfigURL: server.configURLForOrg("my-org"),
+		}, provider, WithRetryMax(0))
+		require.NoError(t, err)
+
+		_, err = client.GenerateJitRunnerConfig(ctx, &RunnerScaleSetJitRunnerSetting{}, 1)
+		require.ErrorContains(t, err, "token store unavailable")
+	})
+}
+
+// withShortLivedAdminToken issues admin tokens that are already within the
+// client's refresh window, forcing a re-authentication on every request.
+func withShortLivedAdminToken(t *testing.T) actionsServerOption {
+	return func(s *actionsServer) {
+		claims := &jwt.RegisteredClaims{
+			IssuedAt:  jwt.NewNumericDate(time.Now().Add(-10 * time.Minute)),
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(30 * time.Second)),
+			Issuer:    "123",
+		}
+		token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+		privateKey, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(samplePrivateKey))
+		require.NoError(t, err)
+		tokenString, err := token.SignedString(privateKey)
+		require.NoError(t, err)
+		s.token = tokenString
+	}
+}
+
+// wrapRegistrationTokenCapture records the Authorization header of every
+// registration-token request before delegating to the wrapped handler.
+func wrapRegistrationTokenCapture(next http.Handler, mu *sync.Mutex, bearers *[]string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/runners/registration-token") {
+			mu.Lock()
+			*bearers = append(*bearers, r.Header.Get("Authorization"))
+			mu.Unlock()
+		}
+		next.ServeHTTP(w, r)
+	})
+}


### PR DESCRIPTION
## What

Generalizes PAT auth into a `TokenProvider` interface consulted on every re-authentication, so callers using short-lived credentials, GitHub App installation tokens in particular, can rotate them without rebuilding the client.

```go
// The new seam: anything that can produce a bearer token.
type TokenProvider interface {
	Token(ctx context.Context) (string, error)
}
```

Two ways in:

- **`NewClientWithPersonalAccessToken`**: unchanged public API; now the degenerate case of a provider returning a constant.
- **`NewClientWithTokenProvider`**: new constructor accepting any `TokenProvider`. Plus `TokenProviderFunc`, a function adapter (`http.HandlerFunc` style).

The token is sent verbatim as `Authorization: Bearer` for a single request; the client neither inspects nor caches it. A provider handing out expiring credentials therefore owns their renewal, which is the point of the seam: renewal can then be shared across clients and processes rather than duplicated inside each one.

The doc comment spells out which credential types are valid at which config-URL scope:

- **Enterprise** (`https://HOST/enterprises/NAME`) requires a PAT with `manage_runners:enterprise`. Today a GitHub App is installed on an organization or a repository, never on an enterprise, so no installation token can be minted at this scope. Nothing in the client enforces that: if GitHub ships enterprise-installable Apps, their installation tokens flow through this seam unchanged.
- **Organization**: a PAT with `admin:org`, or an installation token from an App holding `organization_self_hosted_runners`.
- **Repository**: a PAT with `repo`, or an installation token from an App holding `administration`.

## Why

At fleet scale, installation-token minting is rate limited and worth coordinating across processes: a shared cache, a single-flight mint, credential selection by remaining quota. A client that mints its own token cannot participate in that coordination; one that asks for a token can. Today the bearer is a fixed string captured at construction, so short-lived credentials force client rebuilds.

This is not speculative: we run this in production today against GitHub Enterprise Cloud with data residency, with installation tokens minted and renewed outside the client and handed in through this seam.

## Testing

`go build ./...` and `go test -race ./...` green across the repo. New coverage in `token_provider_test.go`: nil-provider rejection, the provider being consulted on every re-authentication (not cached), provider-error propagation, and `TokenProviderFunc` passthrough.

## Compatibility

- No exported symbol changes signature or is removed; `NewClientWithPersonalAccessToken` is untouched.
- Credential validation becomes exactly-one-of {PAT, token provider, App credentials}, but the pre-existing App+PAT conflict keeps its original error wording, so callers matching on that string are unaffected.

---

**Stacked on #117** (pluggable JWT signing): shares its exactly-one-of validation with the `jwtProvider` field introduced there. Only the last commit (`feat(client): TokenProvider for externally minted bearer tokens`) is new to review here; this rebases to a single commit once #117 lands.
