### PR TITLE
fix: re-create the message session on refresh 404 instead of failing

### DIFF
--- a/session_client.go
+++ b/session_client.go
@@ -97,6 +97,41 @@ func (c *MessageSessionClient) refreshMessageSession(ctx context.Context, expire
 	return nil
 }
 
+// refreshOrRecreateSession refreshes the message session; when the service no
+// longer knows the session (404 on the refresh), it creates a fresh session in
+// place instead of failing. Without this, a broker-side session eviction is
+// fatal to the caller on every token refresh even though a new session would
+// work fine — and the caller's message cursor (lastMessageId, passed per
+// request) survives re-creation. Only the 404 path re-creates; every other
+// refresh failure surfaces exactly as before.
+func (c *MessageSessionClient) refreshOrRecreateSession(ctx context.Context, expiredSession RunnerScaleSetSession) error {
+	refreshErr := c.refreshMessageSession(ctx, expiredSession)
+	if refreshErr == nil {
+		return nil
+	}
+	if !errors.Is(refreshErr, NotFoundError) {
+		return refreshErr
+	}
+	if createErr := c.recreateMessageSession(ctx, expiredSession); createErr != nil {
+		return fmt.Errorf("%w (session was gone; re-create also failed: %v)", refreshErr, createErr)
+	}
+	return nil
+}
+
+// recreateMessageSession mirrors refreshMessageSession's locking and
+// double-check: if another goroutine already replaced the session, do nothing.
+func (c *MessageSessionClient) recreateMessageSession(ctx context.Context, expiredSession RunnerScaleSetSession) error {
+	c.refreshMu.Lock()
+	defer c.refreshMu.Unlock()
+
+	session := c.Session()
+	if session.SessionID != expiredSession.SessionID {
+		return nil
+	}
+
+	return c.createMessageSession(ctx)
+}
+
 // GetMessage fetches a message from the runner scale set message queue. If there are no messages available, it returns (nil, nil).
 // Unless a message is deleted after being processed (using DeleteMessage), it will be returned again in subsequent calls.
 // If the current session token is expired, it refreshes the session and tries one more time.
@@ -116,7 +151,7 @@ func (c *MessageSessionClient) GetMessage(ctx context.Context, lastMessageID int
 		return nil, fmt.Errorf("failed to get next message: %w", err)
 	}
 
-	if err := c.refreshMessageSession(ctx, session); err != nil {
+	if err := c.refreshOrRecreateSession(ctx, session); err != nil {
 		return nil, fmt.Errorf("failed to refresh message session: %w", err)
 	}
 
@@ -189,7 +224,7 @@ func (c *MessageSessionClient) DeleteMessage(ctx context.Context, messageID int)
 		return fmt.Errorf("failed to delete message: %w", err)
 	}
 
-	if err := c.refreshMessageSession(ctx, session); err != nil {
+	if err := c.refreshOrRecreateSession(ctx, session); err != nil {
 		return fmt.Errorf("failed to refresh message session: %w", err)
 	}
 
@@ -252,7 +287,7 @@ func (c *MessageSessionClient) AcquireJobs(ctx context.Context, requestIDs []int
 		return nil, fmt.Errorf("failed to acquire jobs: %w", err)
 	}
 
-	if err := c.refreshMessageSession(ctx, session); err != nil {
+	if err := c.refreshOrRecreateSession(ctx, session); err != nil {
 		return nil, fmt.Errorf("failed to refresh message session: %w", err)
 	}
 
@@ -310,6 +345,13 @@ func (c *MessageSessionClient) doSessionRequest(ctx context.Context, method, pat
 	defer resp.Body.Close()
 
 	if resp.StatusCode != expectedResponseStatusCode {
+		// A 404 on a session request means the service no longer knows the
+		// session (or the scale set behind it). Surface the typed sentinel so
+		// callers can distinguish "session evicted, safe to re-create" from
+		// genuine failures.
+		if resp.StatusCode == http.StatusNotFound {
+			return newRequestResponseError(req, resp, NotFoundError)
+		}
 		return newRequestResponseError(req, resp, fmt.Errorf("unexpected status code %s", resp.Status))
 	}
 

--- a/session_client_test.go
+++ b/session_client_test.go
@@ -952,3 +952,112 @@ func TestAcquireJobs(t *testing.T) {
 		assert.Empty(t, got)
 	})
 }
+
+// A broker-side session eviction makes every refresh 404 even though the scale
+// set still exists and a new session would work. The client must re-create the
+// session in place — preserving the caller's message cursor — rather than
+// surface a fatal error on every token refresh.
+func TestGetMessageSessionRecreate(t *testing.T) {
+	ctx := context.Background()
+	auth := actionsAuth{token: "token"}
+	response := []byte(`{"messageId":7,"messageType":"RunnerScaleSetJobMessages"}`)
+
+	t.Run("refresh 404 recreates the session and the retried get succeeds", func(t *testing.T) {
+		var creates, refreshes, gets int
+		var lastMessageIDSeen string
+		var handleSessionRequest http.HandlerFunc
+		s := newActionsServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case strings.Contains(r.URL.Path, "/sessions/") && r.Method == http.MethodPatch:
+				refreshes++
+				w.WriteHeader(http.StatusNotFound)
+				w.Write([]byte(`{"typeName":"RunnerAdminException","message":"runner referenced a session ID that doesn't exist in redis"}`))
+			case strings.HasSuffix(r.URL.Path, "sessions") && r.Method == http.MethodPost:
+				creates++
+				handleSessionRequest(w, r)
+			default: // message queue GET
+				gets++
+				if gets == 1 {
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+				lastMessageIDSeen = r.URL.Query().Get("lastMessageId")
+				w.Write(response)
+			}
+		}))
+		handleSessionRequest = newTestSessionRequestHandler(t, s.testRunnerScaleSetSession())
+
+		client, err := newClient(testSystemInfo, s.configURLForOrg("my-org"), auth)
+		require.NoError(t, err)
+		sessionClient, err := client.MessageSessionClient(ctx, 1, "my-org")
+		require.NoError(t, err)
+		creates = 0 // ignore the initial session creation
+
+		got, err := sessionClient.GetMessage(ctx, 42, 10)
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, 7, got.MessageID)
+		assert.Equal(t, 1, refreshes, "exactly one refresh attempt")
+		assert.Equal(t, 1, creates, "exactly one re-create after the 404")
+		assert.Equal(t, "42", lastMessageIDSeen, "caller-held cursor must survive re-creation")
+	})
+
+	t.Run("non-404 refresh failure does not recreate", func(t *testing.T) {
+		var creates int
+		var handleSessionRequest http.HandlerFunc
+		s := newActionsServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case strings.Contains(r.URL.Path, "/sessions/") && r.Method == http.MethodPatch:
+				w.WriteHeader(http.StatusInternalServerError)
+			case strings.HasSuffix(r.URL.Path, "sessions") && r.Method == http.MethodPost:
+				creates++
+				handleSessionRequest(w, r)
+			default:
+				w.WriteHeader(http.StatusUnauthorized)
+			}
+		}))
+		handleSessionRequest = newTestSessionRequestHandler(t, s.testRunnerScaleSetSession())
+
+		client, err := newClient(testSystemInfo, s.configURLForOrg("my-org"), auth)
+		require.NoError(t, err)
+		sessionClient, err := client.MessageSessionClient(ctx, 1, "my-org")
+		require.NoError(t, err)
+		creates = 0
+
+		_, err = sessionClient.GetMessage(ctx, 0, 10)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to refresh message session")
+		assert.Equal(t, 0, creates, "a 500 on refresh must not trigger re-create")
+	})
+
+	t.Run("refresh 404 with failing re-create surfaces both errors", func(t *testing.T) {
+		var creates int
+		var handleSessionRequest http.HandlerFunc
+		s := newActionsServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case strings.Contains(r.URL.Path, "/sessions/") && r.Method == http.MethodPatch:
+				w.WriteHeader(http.StatusNotFound)
+			case strings.HasSuffix(r.URL.Path, "sessions") && r.Method == http.MethodPost:
+				creates++
+				if creates == 1 {
+					handleSessionRequest(w, r)
+					return
+				}
+				w.WriteHeader(http.StatusInternalServerError)
+			default:
+				w.WriteHeader(http.StatusUnauthorized)
+			}
+		}))
+		handleSessionRequest = newTestSessionRequestHandler(t, s.testRunnerScaleSetSession())
+
+		client, err := newClient(testSystemInfo, s.configURLForOrg("my-org"), auth)
+		require.NoError(t, err)
+		sessionClient, err := client.MessageSessionClient(ctx, 1, "my-org")
+		require.NoError(t, err)
+
+		_, err = sessionClient.GetMessage(ctx, 0, 10)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, NotFoundError)
+		assert.Contains(t, err.Error(), "re-create also failed")
+	})
+}


### PR DESCRIPTION
We run ARC (0.14.2) for a fleet of orgs and hit a nasty failure mode on one of them: the broker evicts every message session server-side, so the listener's session refresh always comes back 404 with `RunnerAdminException: runner referenced a session ID that doesn't exist in redis`. The client treats any refresh failure as fatal, the error bubbles out of `GetMessage`, and the listener process exits.

Since the refresh happens on the token cycle, the listener for that org died every ~50 minutes, around the clock, for almost two weeks before we noticed. Readiness probes never caught it because the pod is back in a few seconds. The part that actually hurts is that each restart throws away the in-memory `lastMessageID`, so the message cursor resets to 0 every time.

There are a few issues in the ARC repo that look like the same family (actions/actions-runner-controller#4356, actions/actions-runner-controller#3942), and actions/actions-runner-controller#4571 explicitly punts on healing an already crash-looping listener, so the session client seemed like the right place to fix it.

The change: when a session refresh comes back 404, create a new session in place and retry once instead of giving up. A 404 on refresh means the service doesn't know the session anymore, so there's nothing left to lose by re-creating. Everything else (500s, network errors, token expiry itself) behaves exactly as before. Session-request 404s now map to the existing `NotFoundError` sentinel so callers aren't string-matching, and the re-create runs under the same mutex and session-identity double-check that refresh already uses, wired through the three places that do the refresh-and-retry dance (`GetMessage`, `DeleteMessage`, `AcquireJobs`).

`lastMessageID` is owned by the caller and sent on every request, so the delivery position survives the swap. Worst case, a re-created session behaves like what a process restart already does today, minus losing the cursor.

Tests cover the recovery path (including that the caller's `lastMessageId` still goes out on the retried request against the new session), that a 500 on refresh does not trigger a re-create, and that a failed re-create surfaces both errors with `errors.Is(err, NotFoundError)` intact.

For what it's worth, we've been running this patch in production (backported onto v0.4.0): the affected org's listeners went from dying every 50 minutes to logging a single re-create line and moving on. Happy to reshape it if you'd rather see the recovery live in the listener instead of the client, or handled differently.
