### PR TITLE
Add a factory for isolated retryable HTTP clients

### DIFF
--- a/common_client.go
+++ b/common_client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"maps"
 	"net/http"
 	"slices"
 	"time"
@@ -136,11 +137,15 @@ func (o *httpClientOption) newRetryableHTTPClient() (*retryablehttp.Client, erro
 		// cleanhttp.DefaultPooledTransport()
 		return nil, fmt.Errorf("failed to get http transport from retryablehttp client")
 	}
+	// HTTP/2 initialization can add handlers to this map.
+	transport.TLSNextProto = maps.Clone(transport.TLSNextProto)
 	if transport.TLSClientConfig == nil {
 		transport.TLSClientConfig = &tls.Config{}
 	} else {
 		// A fresh transport can still share its TLS config with another client.
 		transport.TLSClientConfig = transport.TLSClientConfig.Clone()
+		// HTTP/2 initialization can append to the transport's protocol list.
+		transport.TLSClientConfig.NextProtos = slices.Clone(transport.TLSClientConfig.NextProtos)
 	}
 
 	if o.rootCAs != nil {

--- a/common_client.go
+++ b/common_client.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"slices"
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
@@ -78,7 +79,7 @@ type httpClientOption struct {
 	logger *slog.Logger
 
 	// Options for built-in retryable HTTP client.
-	// Ignored if a custom retryable HTTP client is provided via WithRetryableHTTPClint.
+	// Ignored when a custom retryable HTTP client or factory is provided.
 	retryMax     int
 	retryWaitMax time.Duration
 
@@ -89,7 +90,8 @@ type httpClientOption struct {
 	proxyFunc             ProxyFunc
 	timeout               time.Duration
 
-	retryableHTTPClient *retryablehttp.Client
+	retryableHTTPClient        *retryablehttp.Client
+	retryableHTTPClientFactory func() *retryablehttp.Client
 }
 
 func (o *httpClientOption) defaults() {
@@ -109,7 +111,12 @@ func (o *httpClientOption) defaults() {
 
 func (o *httpClientOption) newRetryableHTTPClient() (*retryablehttp.Client, error) {
 	var retryClient *retryablehttp.Client
-	if o.retryableHTTPClient != nil {
+	if o.retryableHTTPClientFactory != nil {
+		retryClient = o.retryableHTTPClientFactory()
+		if retryClient == nil || retryClient.HTTPClient == nil {
+			return nil, fmt.Errorf("retryable HTTP client factory returned a nil client")
+		}
+	} else if o.retryableHTTPClient != nil {
 		retryClient = o.retryableHTTPClient
 	} else {
 		retryClient = retryablehttp.NewClient()
@@ -131,6 +138,9 @@ func (o *httpClientOption) newRetryableHTTPClient() (*retryablehttp.Client, erro
 	}
 	if transport.TLSClientConfig == nil {
 		transport.TLSClientConfig = &tls.Config{}
+	} else {
+		// A fresh transport can still share its TLS config with another client.
+		transport.TLSClientConfig = transport.TLSClientConfig.Clone()
 	}
 
 	if o.rootCAs != nil {
@@ -143,7 +153,7 @@ func (o *httpClientOption) newRetryableHTTPClient() (*retryablehttp.Client, erro
 
 	if len(o.tlsClientCertificates) > 0 {
 		transport.TLSClientConfig.Certificates = append(
-			transport.TLSClientConfig.Certificates,
+			slices.Clone(transport.TLSClientConfig.Certificates),
 			o.tlsClientCertificates...,
 		)
 	}
@@ -177,9 +187,26 @@ type HTTPOption func(*httpClientOption)
 
 // WithRetryableHTTPClint allows users to provide a custom retryable HTTP client.
 // If not set, a default client will be used with the specified retry and timeout settings.
+//
+// Deprecated: Use WithRetryableHTTPClientFactory. Token refresh changes the
+// retry policy, which can race with requests that share this client.
 func WithRetryableHTTPClint(client *retryablehttp.Client) HTTPOption {
 	return func(c *httpClientOption) {
 		c.retryableHTTPClient = client
+		c.retryableHTTPClientFactory = nil
+	}
+}
+
+// WithRetryableHTTPClientFactory creates a custom client for each SDK HTTP client,
+// including token refresh and message sessions. The factory must return a new
+// retryable client, http.Client, and *http.Transport each time. The SDK applies
+// HTTP options and can change the retry policy before it uses each client.
+// The factory must be safe to call concurrently. The last custom-client option wins.
+// A nil factory selects the default client.
+func WithRetryableHTTPClientFactory(factory func() *retryablehttp.Client) HTTPOption {
+	return func(c *httpClientOption) {
+		c.retryableHTTPClientFactory = factory
+		c.retryableHTTPClient = nil
 	}
 }
 
@@ -229,7 +256,8 @@ func WithoutTLSVerify() HTTPOption {
 // tls.Config.GetClientCertificate instead.
 func WithTLSClientCertificate(cert tls.Certificate) HTTPOption {
 	return func(c *httpClientOption) {
-		c.tlsClientCertificates = append(c.tlsClientCertificates, cert)
+		// Message sessions copy options. Do not append into a parent's array.
+		c.tlsClientCertificates = append(slices.Clone(c.tlsClientCertificates), cert)
 	}
 }
 

--- a/http_client_factory_test.go
+++ b/http_client_factory_test.go
@@ -1,0 +1,246 @@
+package scaleset
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/hashicorp/go-retryablehttp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRetryableHTTPClientFactory(t *testing.T) {
+	opts := defaultHTTPClientOption()
+	WithRetryableHTTPClientFactory(func() *retryablehttp.Client {
+		client := retryablehttp.NewClient()
+		client.RetryMax = 7
+		client.RetryWaitMax = time.Second
+		return client
+	})(&opts)
+	first, err := opts.newRetryableHTTPClient()
+	require.NoError(t, err)
+	second, err := opts.newRetryableHTTPClient()
+	require.NoError(t, err)
+	assert.NotSame(t, first, second)
+	assert.NotSame(t, first.HTTPClient, second.HTTPClient)
+	assert.NotSame(t, first.HTTPClient.Transport, second.HTTPClient.Transport)
+	assert.Equal(t, 7, second.RetryMax)
+	assert.Equal(t, time.Second, second.RetryWaitMax)
+	assert.Equal(t, opts.timeout, second.HTTPClient.Timeout)
+	assert.Same(t, opts.logger, second.Logger)
+	second.RetryMax = 1
+	assert.Equal(t, 7, first.RetryMax)
+}
+
+func TestRetryableHTTPClientFactoryRejectsNil(t *testing.T) {
+	for _, client := range []*retryablehttp.Client{nil, {}} {
+		opts := defaultHTTPClientOption()
+		WithRetryableHTTPClientFactory(func() *retryablehttp.Client { return client })(&opts)
+		_, err := opts.newRetryableHTTPClient()
+		require.ErrorContains(t, err, "factory returned a nil client")
+	}
+}
+
+func TestRetryableHTTPClientOptionPrecedence(t *testing.T) {
+	legacy := retryablehttp.NewClient()
+	factory := WithRetryableHTTPClientFactory(retryablehttp.NewClient)
+	for _, factoryLast := range []bool{false, true} {
+		opts := defaultHTTPClientOption()
+		if factoryLast {
+			WithRetryableHTTPClint(legacy)(&opts)
+			factory(&opts)
+		} else {
+			factory(&opts)
+			WithRetryableHTTPClint(legacy)(&opts)
+		}
+		client, err := opts.newRetryableHTTPClient()
+		require.NoError(t, err)
+		if factoryLast {
+			assert.NotSame(t, legacy, client)
+		} else {
+			assert.Same(t, legacy, client)
+		}
+	}
+}
+
+type factoryRoundTripper func(*http.Request) (*http.Response, error)
+
+func (f factoryRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	return f(request)
+}
+
+func TestCustomClientRefreshWithInflightJIT(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		const inflight = 16
+		entered := make(chan struct{}, inflight)
+		release := make(chan struct{})
+		var jitCount, adminCount, clientCount atomic.Int64
+		factory := func() *retryablehttp.Client {
+			clientCount.Add(1)
+			client := retryablehttp.NewClient()
+			client.HTTPClient.Transport.(*http.Transport).RegisterProtocol("https", factoryRoundTripper(func(req *http.Request) (*http.Response, error) {
+				code, body := http.StatusOK, ""
+				switch {
+				case strings.HasSuffix(req.URL.Path, "/registration-token"):
+					code = http.StatusCreated
+					body = `{"token":"registration-token"}`
+				case req.URL.Path == "/actions/runner-registration":
+					expires := time.Now().Add(time.Hour)
+					if adminCount.Add(1) == 1 {
+						expires = time.Now().Add(61 * time.Second)
+					}
+					claims := base64.RawURLEncoding.EncodeToString([]byte(fmt.Sprintf(`{"exp":%d}`, expires.Unix())))
+					token := "eyJhbGciOiJub25lIn0." + claims + "."
+					body = fmt.Sprintf(`{"url":"https://actions.example/","token":%q}`, token)
+				case strings.HasSuffix(req.URL.Path, "/generatejitconfig"):
+					id := jitCount.Add(1)
+					if id > 1 && id <= inflight+1 {
+						entered <- struct{}{}
+						<-release
+					}
+					body = fmt.Sprintf(`{"runner":{"id":%d},"encodedJITConfig":"config"}`, id)
+				default:
+					return nil, fmt.Errorf("unexpected request: %s %s", req.Method, req.URL)
+				}
+				return &http.Response{
+					StatusCode: code, Header: make(http.Header), Request: req,
+					Body: io.NopCloser(strings.NewReader(body)),
+				}, nil
+			}))
+			return client
+		}
+		client, err := NewClientWithPersonalAccessToken(NewClientWithPersonalAccessTokenConfig{
+			GitHubConfigURL: "https://github.com/example-org", PersonalAccessToken: "example-token",
+		}, WithRetryableHTTPClientFactory(factory))
+		require.NoError(t, err)
+		generate := func(ctx context.Context, name string) error {
+			_, err := client.GenerateJitRunnerConfig(ctx, &RunnerScaleSetJitRunnerSetting{Name: name, WorkFolder: "_work"}, 1)
+			return err
+		}
+		require.NoError(t, generate(t.Context(), "warm"))
+		var workers sync.WaitGroup
+		errs := make([]error, inflight)
+		for i := range inflight {
+			workers.Go(func() { errs[i] = generate(t.Context(), fmt.Sprintf("inflight-%d", i)) })
+		}
+		for range inflight {
+			<-entered
+		}
+		time.Sleep(2 * time.Second)
+		close(release)
+		refreshErr := generate(t.Context(), "refresh")
+		workers.Wait()
+		require.NoError(t, refreshErr)
+		for _, err := range errs {
+			assert.NoError(t, err)
+		}
+		assert.Equal(t, int64(2), adminCount.Load())
+		assert.GreaterOrEqual(t, clientCount.Load(), int64(3))
+	})
+}
+
+func TestRetryableHTTPClientFactoryIsolatesMessageSession(t *testing.T) {
+	server := newActionsServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		w.Write([]byte(`{"sessionId":"00000000-0000-0000-0000-000000000001"}`))
+	}))
+	client, err := newClient(testSystemInfo, server.configURLForOrg("example-org"), actionsAuth{token: "token"},
+		WithRetryableHTTPClientFactory(retryablehttp.NewClient))
+	require.NoError(t, err)
+	parent := client.httpClient.Transport.(*retryablehttp.RoundTripper).Client
+	parentTransport := parent.HTTPClient.Transport.(*http.Transport)
+	logger := slog.New(slog.DiscardHandler)
+	session, err := client.MessageSessionClient(t.Context(), 1, "owner", WithLogger(logger), WithoutTLSVerify())
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, session.Close(context.Background())) })
+	child := session.commonClient.httpClient.Transport.(*retryablehttp.RoundTripper).Client
+	childTransport := child.HTTPClient.Transport.(*http.Transport)
+	assert.NotSame(t, parent, child)
+	assert.NotSame(t, parent.HTTPClient, child.HTTPClient)
+	assert.NotSame(t, parentTransport, childTransport)
+	assert.Same(t, logger, child.Logger)
+	assert.NotSame(t, logger, parent.Logger)
+	assert.True(t, childTransport.TLSClientConfig.InsecureSkipVerify)
+	assert.False(t, parentTransport.TLSClientConfig.InsecureSkipVerify)
+}
+
+func TestRetryableHTTPClientFactoryCopiesTLSConfig(t *testing.T) {
+	shared := &tls.Config{Certificates: make([]tls.Certificate, 1, 4)}
+	opts := defaultHTTPClientOption()
+	WithRetryableHTTPClientFactory(func() *retryablehttp.Client {
+		client := retryablehttp.NewClient()
+		client.HTTPClient.Transport.(*http.Transport).TLSClientConfig = shared
+		return client
+	})(&opts)
+	parent, err := opts.newRetryableHTTPClient()
+	require.NoError(t, err)
+	parentConfig := parent.HTTPClient.Transport.(*http.Transport).TLSClientConfig
+	const sessions = 16
+	configs := make([]*tls.Config, sessions)
+	errs := make([]error, sessions)
+	var workers sync.WaitGroup
+	for i := range sessions {
+		workers.Go(func() {
+			childOpts := opts
+			WithoutTLSVerify()(&childOpts)
+			WithTLSClientCertificate(tls.Certificate{Certificate: [][]byte{{byte(i)}}})(&childOpts)
+			child, err := childOpts.newRetryableHTTPClient()
+			errs[i] = err
+			if err == nil {
+				configs[i] = child.HTTPClient.Transport.(*http.Transport).TLSClientConfig
+			}
+		})
+	}
+	workers.Go(func() {
+		for range sessions {
+			// The HTTP transport clones the TLS config before a handshake.
+			assert.False(t, parentConfig.Clone().InsecureSkipVerify)
+		}
+	})
+	workers.Wait()
+	for i, config := range configs {
+		require.NoError(t, errs[i])
+		assert.NotSame(t, parentConfig, config)
+		assert.True(t, config.InsecureSkipVerify)
+		require.Len(t, config.Certificates, 2)
+		assert.Equal(t, []byte{byte(i)}, config.Certificates[1].Certificate[0])
+	}
+	assert.False(t, shared.InsecureSkipVerify)
+	assert.False(t, parentConfig.InsecureSkipVerify)
+	assert.Empty(t, shared.Certificates[:cap(shared.Certificates)][1].Certificate)
+}
+
+func TestMessageSessionCertificateOptionsDoNotShareArray(t *testing.T) {
+	opts := defaultHTTPClientOption()
+	opts.tlsClientCertificates = make([]tls.Certificate, 3, 4)
+	const sessions = 16
+	children := make([]httpClientOption, sessions)
+	var workers sync.WaitGroup
+	for i := range sessions {
+		workers.Go(func() {
+			// MessageSessionClient copies the parent options before overrides.
+			children[i] = opts
+			WithTLSClientCertificate(tls.Certificate{Certificate: [][]byte{{byte(i)}}})(&children[i])
+		})
+	}
+	workers.Wait()
+	for i, child := range children {
+		require.Len(t, child.tlsClientCertificates, 4)
+		assert.Equal(t, []byte{byte(i)}, child.tlsClientCertificates[3].Certificate[0])
+	}
+	assert.Empty(t, opts.tlsClientCertificates[:cap(opts.tlsClientCertificates)][3].Certificate)
+}

--- a/http_client_factory_test.go
+++ b/http_client_factory_test.go
@@ -179,7 +179,11 @@ func TestRetryableHTTPClientFactoryIsolatesMessageSession(t *testing.T) {
 }
 
 func TestRetryableHTTPClientFactoryCopiesTLSConfig(t *testing.T) {
-	shared := &tls.Config{Certificates: make([]tls.Certificate, 1, 4)}
+	shared := &tls.Config{
+		Certificates: make([]tls.Certificate, 1, 4),
+		NextProtos:   make([]string, 1, 4),
+	}
+	shared.NextProtos[0] = "h2"
 	opts := defaultHTTPClientOption()
 	WithRetryableHTTPClientFactory(func() *retryablehttp.Client {
 		client := retryablehttp.NewClient()
@@ -201,7 +205,10 @@ func TestRetryableHTTPClientFactoryCopiesTLSConfig(t *testing.T) {
 			child, err := childOpts.newRetryableHTTPClient()
 			errs[i] = err
 			if err == nil {
-				configs[i] = child.HTTPClient.Transport.(*http.Transport).TLSClientConfig
+				transport := child.HTTPClient.Transport.(*http.Transport)
+				// This also initializes HTTP/2, as the first request would.
+				transport.CloseIdleConnections()
+				configs[i] = transport.TLSClientConfig
 			}
 		})
 	}
@@ -222,6 +229,7 @@ func TestRetryableHTTPClientFactoryCopiesTLSConfig(t *testing.T) {
 	assert.False(t, shared.InsecureSkipVerify)
 	assert.False(t, parentConfig.InsecureSkipVerify)
 	assert.Empty(t, shared.Certificates[:cap(shared.Certificates)][1].Certificate)
+	assert.Empty(t, shared.NextProtos[:cap(shared.NextProtos)][1])
 }
 
 func TestMessageSessionCertificateOptionsDoNotShareArray(t *testing.T) {
@@ -243,4 +251,27 @@ func TestMessageSessionCertificateOptionsDoNotShareArray(t *testing.T) {
 		assert.Equal(t, []byte{byte(i)}, child.tlsClientCertificates[3].Certificate[0])
 	}
 	assert.Empty(t, opts.tlsClientCertificates[:cap(opts.tlsClientCertificates)][3].Certificate)
+}
+
+func TestRetryableHTTPClientFactoryCopiesProtocolHandlers(t *testing.T) {
+	protocols := new(http.Protocols)
+	protocols.SetHTTP1(true)
+	protocols.SetHTTP2(true)
+	shared := make(map[string]func(string, *tls.Conn) http.RoundTripper)
+	opts := defaultHTTPClientOption()
+	WithRetryableHTTPClientFactory(func() *retryablehttp.Client {
+		client := retryablehttp.NewClient()
+		transport := client.HTTPClient.Transport.(*http.Transport)
+		transport.Protocols = protocols
+		transport.TLSNextProto = shared
+		return client
+	})(&opts)
+	var workers sync.WaitGroup
+	for range 16 {
+		client, err := opts.newRetryableHTTPClient()
+		require.NoError(t, err)
+		workers.Go(client.HTTPClient.CloseIdleConnections)
+	}
+	workers.Wait()
+	assert.Empty(t, shared)
 }


### PR DESCRIPTION
Add a factory that gives each SDK HTTP client its own retry client and transport.

Authored by Timer's automated agent.

## Problem

`WithRetryableHTTPClint` returns the same client during token refresh and message-session creation. Token refresh changes `CheckRetry` and `ErrorHandler` on that client. Concurrent JIT requests can read those fields at the same time. The race detector confirms this interleaving.

Session-specific HTTP options can also change settings on a shared client. A fresh transport alone does not isolate a shared TLS config or its certificate array.

## Change

- Add `WithRetryableHTTPClientFactory`. The factory returns a fresh retry client, `http.Client`, and `*http.Transport` for each SDK client.
- Keep `WithRetryableHTTPClint` for compatibility, but deprecate it. Callers must use the factory to avoid the shared-client race.
- Copy a transport's TLS config before the SDK applies options. Copy certificate arrays, the protocol list, and protocol handlers before use.
- Preserve custom retry settings. The last custom-client option takes precedence. A nil factory selects the default client.

## Verification

- Reproduce token refresh with 16 concurrent JIT requests. The legacy option reports a race; the factory passes.
- Check message-session settings, shared TLS configs, certificate arrays, option precedence, and invalid factory results.
- The focused tests pass 30 shuffled runs with the race detector. Go vet and the repository linter pass.
- The complete race-test suite passes in a local Linux container with the official `golang:1.26.3` image. The source mount was read-only.
- On macOS, the full suite fails the error-string assertion in `TestServerWithSelfSignedCertificates/client_without_ca_certs`. The same assertion fails on untouched upstream commit `cb0405b2d874`. This PR does not change that test.
- Hosted Go and E2E CI need maintainer approval for the fork before they can run.

Docs/knowledge: API comments describe the new option and its ownership contract.
